### PR TITLE
Rich relationship structure 3

### DIFF
--- a/api/server/routes/graphql/api.js
+++ b/api/server/routes/graphql/api.js
@@ -35,6 +35,7 @@ const updateAPI = () => {
 		}
 	} catch (error) {
 		schemaVersionIsConsistent = false;
+		console.log('jenny error.....', error)
 		logger.error(
 			{ event: 'GRAPHQL_SCHEMA_UPDATE_FAILED', error },
 			'Graphql schema update failed',

--- a/packages/schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/schema-sdk/data-accessors/graphql-defs.js
@@ -180,7 +180,7 @@ const defineRelationshipType = (firstNode) => ([name, def]) => {
 	const fullNameCaps = `${from.toUpperCase()}_${
 		def.relationship
 	}_${to.toUpperCase()}`;
-	return `\n\ttype ${snakeToCamel(fullNameCaps)} @relation(name: ${fullNameCaps}) {
+	return `\n\ttype ${snakeToCamel(fullNameCaps)} @relation(name: ${def.relationship}) {
 		from: ${from}
 		to: ${to}
 	}`;

--- a/packages/schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/schema-sdk/data-accessors/graphql-defs.js
@@ -84,20 +84,19 @@ const defineProperties = properties => {
 };
 
 const definePropertiesForRelationshipSchema = (properties, firstNode) => {
-	const retVal = properties
-	.map(
-		([name, def]) => {
-			const mapVal = stripEmptyFirstLine`
-			"""
-			${def.description}
-			"""
-			${name}${maybePaginate(def)}: ${def.isRelationship ? relationshipPluralType(def, firstNode) : maybePluralType(def)} ${maybeDeprecate(def)}`
-			return mapVal
-		}
+	return properties
+		.map(
+			([name, def]) => {
+				const mapVal = stripEmptyFirstLine`
+				"""
+				${def.description}
+				"""
+				${name}${maybePaginate(def)}: ${def.isRelationship ? relationshipPluralType(def, firstNode) : maybePluralType(def)} ${maybeDeprecate(def)}`
+				return mapVal
+			}
 
-	)
-	.join('');
-	return retVal
+		)
+		.join('');
 };
 
 const relationshipPluralType = (def, firstNode) => {
@@ -162,14 +161,16 @@ const defineTypeWithRelationshipTypes = config => {
 	console.log('defineTypeWithRelationshipTypes ', config.name)
 	const relationshipTypes = defineRelationshipTypes(config)
 	const properties = definePropertiesForRelationshipSchema(Object.entries(config.properties), config.name);
-	const retVal = `
-	"""
-	${config.description}
-	"""
-	type ${config.name} {
-		${indentMultiline(properties, 2, true)}
-	}`
-	return retVal;
+	return [
+		`
+		"""
+		${config.description}
+		"""
+		type ${config.name} {
+			${indentMultiline(properties, 2, true)}
+		}`,
+		...relationshipTypes
+	];
 }
 
 const defineRelationshipTypes = config => {
@@ -272,9 +273,9 @@ module.exports = {
 
 		return [].concat(
 			customDateTimeTypes + uniqueTypeNamesAndDescriptions,
-			// 'type Query {\n',
-			// ...typesFromSchema.map(defineQueries),
-			// '}',
+			'type Query {\n',
+			...typesFromSchema.map(defineQueries),
+			'}',
 			enums,
 		);
 	},


### PR DESCRIPTION
## What
Biz ops schema can generate relationship structure where you can add properties to relationships

## Why
So we can query on relationship properties (eg critically DEPENDS_ON)

## How
Pass representRelationshipsAsNodes (false = old schema structure, true = new schema structure) into the graphql accessor