### PR TITLE
upload to s3 with correct content type

### DIFF
--- a/packages/api-s3-document-store/__tests__/s3-docstore-patch.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-patch.spec.js
@@ -118,6 +118,7 @@ describe('S3 document helper patch', () => {
 			Bucket: TREECREEPER_DOCSTORE_S3_BUCKET,
 			Key: `${consistentNodeType}/${givenSystemCode}`,
 			Body: JSON.stringify(expectedBody),
+			ContentType: 'application/json',
 		};
 
 		expect(result).toMatchObject({

--- a/packages/api-s3-document-store/__tests__/s3-docstore-post.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-post.spec.js
@@ -69,6 +69,7 @@ describe('S3 document helper post', () => {
 			Bucket: TREECREEPER_DOCSTORE_S3_BUCKET,
 			Key: `${consistentNodeType}/${givenSystemCode}`,
 			Body: JSON.stringify(exampleData),
+			ContentType: 'application/json',
 		};
 
 		expect(stubUpload).toHaveBeenCalledTimes(1);

--- a/packages/api-s3-document-store/patch.js
+++ b/packages/api-s3-document-store/patch.js
@@ -31,6 +31,7 @@ const s3Patch = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 		Bucket: bucketName,
 		Key: `${nodeType}/${code}`,
 		Body: JSON.stringify(newBodyDocument),
+		ContentType: 'application/json',
 	};
 	const versionId = await upload({
 		s3Instance,

--- a/packages/api-s3-document-store/post.js
+++ b/packages/api-s3-document-store/post.js
@@ -6,6 +6,7 @@ const s3Post = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 		Bucket: bucketName,
 		Key: `${nodeType}/${code}`,
 		Body: JSON.stringify(body),
+		ContentType: 'application/json',
 	};
 
 	const versionId = await upload({


### PR DESCRIPTION
This PR adds `ContentType` parameter on uploading document to S3.

The parameter is copied From [biz-ops-api](https://github.com/Financial-Times/biz-ops-api/blob/master/server/routes/rest/lib/s3-documents-helper.js#L43), the Content-Type of the document always should be `application/json`, so I add it to logic and updated related tests.

Trello: https://trello.com/c/th5LeEHx/114-update-docstore-to-send-correct-content-type-copy-from-biz-ops-api