### PR TITLE
Document store accepts user's choice of logger

### DIFF
--- a/packages/api-s3-document-store/__tests__/s3-docstore-delete.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-delete.spec.js
@@ -61,7 +61,7 @@ describe('S3 document helper delete', () => {
 			givenSystemCode,
 			givenVersionMarker,
 		);
-		const store = docstore(s3Instance);
+		const store = docstore({ s3Instance });
 
 		const result = await store.delete(
 			consistentNodeType,
@@ -86,6 +86,30 @@ describe('S3 document helper delete', () => {
 		expect(stubDeleteObject).toHaveBeenCalledTimes(2);
 	});
 
+	test('use can choose logger', async () => {
+		const givenSystemCode = 'docstore-delete-test';
+		const givenVersionMarker = 'Mw4owdmcWOlJIW.YZQRRsdksCXwPcTar';
+
+		const { s3Instance } = mockS3DeleteObject(
+			givenSystemCode,
+			givenVersionMarker,
+		);
+		const mockLogger = {
+			info: jest.fn(),
+			error: jest.fn(),
+		};
+		const store = docstore({ s3Instance, logger: mockLogger });
+
+		await expect(
+			store.delete(
+				consistentNodeType,
+				givenSystemCode,
+				givenVersionMarker,
+			),
+		).resolves.not.toThrow();
+		expect(mockLogger.info).toHaveBeenCalledTimes(1);
+	});
+
 	test('throws error when delete fails', async () => {
 		const givenSystemCode = 'docstore-delete-unexpected';
 		const givenVersionMarker = 'Mw4owdmcWOlJIW.YZQRRsdksCXwPcTar';
@@ -94,7 +118,7 @@ describe('S3 document helper delete', () => {
 			givenSystemCode,
 			givenVersionMarker,
 		);
-		const store = docstore(s3Instance);
+		const store = docstore({ s3Instance });
 
 		await expect(
 			store.delete(

--- a/packages/api-s3-document-store/__tests__/s3-docstore-get.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-get.spec.js
@@ -69,7 +69,7 @@ describe('S3 document helper get', () => {
 			expectedData,
 			givenVersionMarker,
 		);
-		const store = docstore(s3Instance);
+		const store = docstore({ s3Instance });
 
 		const result = await store.get(consistentNodeType, givenSystemCode);
 
@@ -78,6 +78,33 @@ describe('S3 document helper get', () => {
 		});
 		expect(stubGetObject).toHaveBeenCalledTimes(1);
 		expect(stubGetObject).toHaveBeenCalledWith(matcher(givenSystemCode));
+	});
+
+	test('user can choose logger', async () => {
+		const givenSystemCode = 'docstore-get-test';
+		const givenVersionMarker = 'Mw4owdmcWOlJIW.YZQRRsdksCXwPcTar';
+		const expectedData = createExampleBodyData();
+
+		const mockLogger = {
+			info: jest.fn(),
+			error: jest.fn(),
+		};
+
+		const { stubGetObject, s3Instance } = mockS3GetObject(
+			givenSystemCode,
+			expectedData,
+			givenVersionMarker,
+		);
+		const store = docstore({ s3Instance, logger: mockLogger });
+
+		const result = await store.get(consistentNodeType, givenSystemCode);
+
+		expect(result).toMatchObject({
+			body: expectedData,
+		});
+		expect(stubGetObject).toHaveBeenCalledTimes(1);
+		expect(stubGetObject).toHaveBeenCalledWith(matcher(givenSystemCode));
+		expect(mockLogger.info).toHaveBeenCalledTimes(1);
 	});
 
 	test('returns empty object when S3 responds with NoSuchKey error', async () => {
@@ -90,7 +117,7 @@ describe('S3 document helper get', () => {
 			expectedData,
 			givenVersionMarker,
 		);
-		const store = docstore(s3Instance);
+		const store = docstore({ s3Instance });
 		const result = await store.get(consistentNodeType, givenSystemCode);
 
 		expect(Object.keys(result)).toHaveLength(0);
@@ -108,7 +135,7 @@ describe('S3 document helper get', () => {
 			expectedData,
 			givenVersionMarker,
 		);
-		const store = docstore(s3Instance);
+		const store = docstore({ s3Instance });
 
 		await expect(
 			store.get(consistentNodeType, givenSystemCode),

--- a/packages/api-s3-document-store/__tests__/s3-docstore-undo.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-undo.spec.js
@@ -6,6 +6,7 @@ const { undo } = require('../undo');
 const {
 	s3DeleteObjectResponseFixture,
 } = require('../__fixtures__/s3-object-fixture');
+const { logger } = require('../../api-express/lib/request-context');
 
 const { TREECREEPER_DOCSTORE_S3_BUCKET } = process.env;
 const consistentNodeType = 'System';
@@ -41,6 +42,7 @@ const mockUndo = (systemCode, versionMarker) => {
 		nodeType: consistentNodeType,
 		code: systemCode,
 		versionMarker,
+		logger,
 	};
 
 	return {

--- a/packages/api-s3-document-store/__tests__/s3-docstore-upload.spec.js
+++ b/packages/api-s3-document-store/__tests__/s3-docstore-upload.spec.js
@@ -7,6 +7,9 @@ const {
 	s3UploadResponseFixture,
 	createExampleBodyData,
 } = require('../__fixtures__/s3-object-fixture');
+const {
+	logger: defaultLogger,
+} = require('../../api-express/lib/request-context');
 
 const { TREECREEPER_DOCSTORE_S3_BUCKET } = process.env;
 
@@ -75,6 +78,7 @@ describe('S3 document helper upload (internal function)', () => {
 			s3Instance,
 			params: callParams,
 			requestType: 'POST',
+			logger: defaultLogger,
 		});
 
 		expect(stubUpload).toHaveBeenCalled();
@@ -104,6 +108,7 @@ describe('S3 document helper upload (internal function)', () => {
 			s3Instance,
 			params: callParams,
 			requestType: 'POST',
+			logger: defaultLogger,
 		});
 
 		expect(stubUpload).toHaveBeenCalled();

--- a/packages/api-s3-document-store/absorb.js
+++ b/packages/api-s3-document-store/absorb.js
@@ -1,5 +1,4 @@
 const _isEmpty = require('lodash.isempty');
-const { logger } = require('../api-express/lib/request-context');
 const { s3Get } = require('./get');
 const { s3Delete } = require('./delete');
 const { s3Post } = require('./post');
@@ -11,13 +10,20 @@ const s3Absorb = async ({
 	nodeType,
 	sourceCode,
 	destinationCode,
+	logger,
 }) => {
 	const [
 		{ body: sourceNodeBody },
 		{ body: destinationNodeBody },
 	] = await Promise.all([
-		s3Get({ s3Instance, bucketName, nodeType, code: sourceCode }),
-		s3Get({ s3Instance, bucketName, nodeType, code: destinationCode }),
+		s3Get({ s3Instance, bucketName, nodeType, code: sourceCode, logger }),
+		s3Get({
+			s3Instance,
+			bucketName,
+			nodeType,
+			code: destinationCode,
+			logger,
+		}),
 	]);
 	// If the source node has no document properties/does not exist
 	// in s3, take no action and return false in place of version ids
@@ -54,6 +60,7 @@ const s3Absorb = async ({
 				code: destinationCode,
 				// We always assign merge values to empty object in order to avoid side-effect to destinationNodeBody unexpectedly.
 				body: Object.assign({}, destinationNodeBody, writeProperties),
+				logger,
 			});
 		} catch (err) {
 			return {};
@@ -70,7 +77,13 @@ const s3Absorb = async ({
 			undo: undoPost = async () => ({ versionMarker: null }),
 		},
 	] = await Promise.all([
-		s3Delete({ s3Instance, bucketName, nodeType, code: sourceCode }),
+		s3Delete({
+			s3Instance,
+			bucketName,
+			nodeType,
+			code: sourceCode,
+			logger,
+		}),
 		postDestinationBody(),
 	]);
 

--- a/packages/api-s3-document-store/delete.js
+++ b/packages/api-s3-document-store/delete.js
@@ -1,4 +1,3 @@
-const { logger } = require('../api-express/lib/request-context');
 const { undo } = require('./undo');
 
 const s3Delete = async ({
@@ -7,6 +6,7 @@ const s3Delete = async ({
 	nodeType,
 	code,
 	versionMarker,
+	logger,
 }) => {
 	const params = {
 		Bucket: bucketName,
@@ -34,10 +34,11 @@ const s3Delete = async ({
 				code,
 				versionMarker: response.VersionId,
 				undoType: 'DELETE',
+				logger,
 			}),
 		};
 	} catch (err) {
-		logger.info(
+		logger.error(
 			{
 				event: `DELETE_S3_FAILURE`,
 			},

--- a/packages/api-s3-document-store/get.js
+++ b/packages/api-s3-document-store/get.js
@@ -1,11 +1,10 @@
-const { logger } = require('../api-express/lib/request-context');
-
 const s3Get = async ({
 	s3Instance,
 	bucketName,
 	nodeType,
 	code,
 	versionMarker,
+	logger,
 }) => {
 	const params = {
 		Bucket: bucketName,

--- a/packages/api-s3-document-store/index.js
+++ b/packages/api-s3-document-store/index.js
@@ -1,3 +1,4 @@
+const { logger: defaultLogger } = require('../api-express/lib/request-context');
 const { defaultS3Instance } = require('./s3');
 const { s3Get } = require('./get');
 const { s3Post } = require('./post');
@@ -7,10 +8,11 @@ const { s3Absorb } = require('./absorb');
 
 const { TREECREEPER_DOCSTORE_S3_BUCKET } = process.env;
 
-const docstore = (
+const docstore = ({
 	s3Instance = defaultS3Instance,
 	bucketName = TREECREEPER_DOCSTORE_S3_BUCKET,
-) => {
+	logger = defaultLogger,
+} = {}) => {
 	return {
 		get: async (nodeType, code) =>
 			s3Get({
@@ -18,6 +20,7 @@ const docstore = (
 				bucketName,
 				nodeType,
 				code,
+				logger,
 			}),
 		post: async (nodeType, code, body) =>
 			s3Post({
@@ -26,6 +29,7 @@ const docstore = (
 				nodeType,
 				code,
 				body,
+				logger,
 			}),
 		patch: async (nodeType, code, body) =>
 			s3Patch({
@@ -34,6 +38,7 @@ const docstore = (
 				nodeType,
 				code,
 				body,
+				logger,
 			}),
 		delete: async (nodeType, code, versionMarker) =>
 			s3Delete({
@@ -42,6 +47,7 @@ const docstore = (
 				nodeType,
 				code,
 				versionMarker,
+				logger,
 			}),
 		absorb: async (nodeType, sourceCode, destinationCode) =>
 			s3Absorb({
@@ -50,13 +56,14 @@ const docstore = (
 				nodeType,
 				sourceCode,
 				destinationCode,
+				logger,
 			}),
 	};
 };
 
 // Factory method which user intend to use their S3 bucket
 const createStore = (s3BucketName = TREECREEPER_DOCSTORE_S3_BUCKET) =>
-	docstore(defaultS3Instance, s3BucketName);
+	docstore({ s3Instance: defaultS3Instance, bucketName: s3BucketName });
 
 module.exports = {
 	docstore,

--- a/packages/api-s3-document-store/patch.js
+++ b/packages/api-s3-document-store/patch.js
@@ -1,15 +1,22 @@
 const { diff } = require('deep-diff');
-const { logger } = require('../api-express/lib/request-context');
 const { upload } = require('./upload');
 const { undo } = require('./undo');
 const { s3Get } = require('./get');
 
-const s3Patch = async ({ s3Instance, bucketName, nodeType, code, body }) => {
+const s3Patch = async ({
+	s3Instance,
+	bucketName,
+	nodeType,
+	code,
+	body,
+	logger,
+}) => {
 	const { body: existingBody } = await s3Get({
 		s3Instance,
 		bucketName,
 		nodeType,
 		code,
+		logger,
 	});
 
 	// If PATCHing body is completely same with existing body,
@@ -37,6 +44,7 @@ const s3Patch = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 		s3Instance,
 		params,
 		requestType: 'PATCH',
+		logger,
 	});
 	return {
 		versionMarker: versionId,
@@ -48,6 +56,7 @@ const s3Patch = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 			code,
 			versionMarker: versionId,
 			undoType: 'PATCH',
+			logger,
 		}),
 	};
 };

--- a/packages/api-s3-document-store/post.js
+++ b/packages/api-s3-document-store/post.js
@@ -1,7 +1,14 @@
 const { upload } = require('./upload');
 const { undo } = require('./undo');
 
-const s3Post = async ({ s3Instance, bucketName, nodeType, code, body }) => {
+const s3Post = async ({
+	s3Instance,
+	bucketName,
+	nodeType,
+	code,
+	body,
+	logger,
+}) => {
 	const params = {
 		Bucket: bucketName,
 		Key: `${nodeType}/${code}`,
@@ -13,6 +20,7 @@ const s3Post = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 		s3Instance,
 		params,
 		requestType: 'POST',
+		logger,
 	});
 
 	return {
@@ -24,6 +32,7 @@ const s3Post = async ({ s3Instance, bucketName, nodeType, code, body }) => {
 			nodeType,
 			code,
 			versionMarker: versionId,
+			logger,
 		}),
 	};
 };

--- a/packages/api-s3-document-store/undo.js
+++ b/packages/api-s3-document-store/undo.js
@@ -1,5 +1,3 @@
-const { logger } = require('../api-express/lib/request-context');
-
 const undo = ({
 	s3Instance,
 	bucketName,
@@ -7,6 +5,7 @@ const undo = ({
 	code,
 	versionMarker,
 	undoType = 'POST',
+	logger,
 }) => async () => {
 	if (!versionMarker) {
 		logger.info(

--- a/packages/api-s3-document-store/upload.js
+++ b/packages/api-s3-document-store/upload.js
@@ -1,6 +1,4 @@
-const { logger } = require('../api-express/lib/request-context');
-
-const upload = async ({ s3Instance, params, requestType }) => {
+const upload = async ({ s3Instance, params, requestType, logger }) => {
 	try {
 		const response = await s3Instance.upload(params).promise();
 		logger.info(
@@ -12,7 +10,7 @@ const upload = async ({ s3Instance, params, requestType }) => {
 		);
 		return response.VersionId;
 	} catch (err) {
-		logger.info(
+		logger.error(
 			{
 				event: `${requestType}_S3_FAILURE`,
 			},


### PR DESCRIPTION
This PR allows injecting custom logger which user chooses into document store.
And I changes the `docstore` constructor signature from a number of arguments to destructuring object.

### Before

```
const store = docstore(s3Instance, bucketName);
```

### After

```
const store = docstore({ s3Instance, bucketName, logger });
```

the `logger` is optional -- default as logger in `api-express/lib/request-context.js`.

I modified related tests and also integrated with `api-rest-handlers`, but actually it doesn't affect to handler's detail. I assume that the document store will be instantiated when application will start.