### PR TITLE
deprecate isRecursive for relationships

### DIFF
--- a/packages/schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
+++ b/packages/schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
@@ -48,10 +48,9 @@ describe('graphql def creation', () => {
 						},
 						hasNestedGroups: {
 							type: 'Group',
-							relationship: 'PAYS_FOR',
-							direction: 'outgoing',
 							hasMany: true,
-							isRecursive: true,
+							cypher:
+								'MATCH (this)-[:PAYS_FOR*1..20]->(related:Group) RETURN DISTINCT related',
 							description:
 								'The recursive groups which are costed to the cost centre',
 						},
@@ -87,14 +86,6 @@ describe('graphql def creation', () => {
 							description:
 								'The Cost Centre associated with the group',
 						},
-						hasEventualBudget: {
-							type: 'CostCentre',
-							description:
-								'The Cost Centre associated with the group in the end',
-							isRecursive: true,
-							relationship: 'PAYS_FOR',
-							direction: 'incoming',
-						},
 					},
 				},
 			],
@@ -120,7 +111,6 @@ describe('graphql def creation', () => {
 		const generated = [].concat(
 			...graphqlFromRawData(schema).map(explodeString),
 		);
-
 		expect(generated).toEqual(
 			explodeString(
 				`
@@ -147,9 +137,7 @@ hasGroups(first: Int, offset: Int): [Group] @relation(name: "PAYS_FOR", directio
 """
 The recursive groups which are costed to the cost centre
 """
-hasNestedGroups(first: Int, offset: Int): [Group] @cypher(
-statement: "MATCH (this)-[:PAYS_FOR*1..20]->(related:Group) RETURN DISTINCT related"
-)
+hasNestedGroups(first: Int, offset: Int): [Group] @cypher(statement: "MATCH (this)-[:PAYS_FOR*1..20]->(related:Group) RETURN DISTINCT related")
 
 """
 The client that was used to make the creation
@@ -204,12 +192,6 @@ isActive: Boolean
 The Cost Centre associated with the group
 """
 hasBudget: CostCentre @relation(name: "PAYS_FOR", direction: "IN")
-"""
-The Cost Centre associated with the group in the end
-"""
-hasEventualBudget: CostCentre @cypher(
-statement: "MATCH (this)<-[:PAYS_FOR*1..20]-(related:CostCentre) RETURN DISTINCT related"
-)
 
 """
 The client that was used to make the creation

--- a/packages/schema-sdk/data-accessors/__tests__/type.spec.js
+++ b/packages/schema-sdk/data-accessors/__tests__/type.spec.js
@@ -626,7 +626,6 @@ describe('get-type', () => {
 				isRelationship: true,
 				showInactive: true,
 				writeInactive: false,
-				isRecursive: false,
 				description: 'test description',
 				label: 'test label',
 			});
@@ -650,7 +649,6 @@ describe('get-type', () => {
 				direction: 'incoming',
 				type: 'Type2',
 				isRelationship: true,
-				isRecursive: false,
 				showInactive: true,
 				writeInactive: false,
 				hasMany: false,
@@ -699,15 +697,14 @@ describe('get-type', () => {
 			expect(type.properties.testName2.direction).toBe('incoming');
 		});
 
-		it('define recursive relationships', () => {
+		it('define relationships with cypher query', () => {
 			const type = typeFromRawData({
 				name: 'Type1',
 				properties: {
 					testName: {
 						type: 'Type2',
-						direction: 'outgoing',
-						isRecursive: true,
-						relationship: 'HAS',
+						cypher:
+							'MATCH (this)-[]->(related) RETURN DISTINCT related',
 						label: 'test label',
 						description: 'test description',
 					},
@@ -717,12 +714,10 @@ describe('get-type', () => {
 			expect(type.properties.testName).toEqual({
 				type: 'Type2',
 				hasMany: false,
-				direction: 'outgoing',
 				showInactive: true,
 				writeInactive: false,
-				isRecursive: true,
+				cypher: 'MATCH (this)-[]->(related) RETURN DISTINCT related',
 				isRelationship: true,
-				relationship: 'HAS',
 				description: 'test description',
 				label: 'test label',
 			});
@@ -743,10 +738,15 @@ describe('get-type', () => {
 						direction: 'incoming',
 						relationship: 'HAS',
 					},
+					cypherMany: {
+						type: 'Type2',
+						hasMany: true,
+						cypher:
+							'MATCH (this)-[]->(related) RETURN DISTINCT related',
+					},
 				},
 			});
 			expect(type.properties.many).toEqual({
-				isRecursive: false,
 				isRelationship: true,
 				showInactive: true,
 				writeInactive: false,
@@ -755,8 +755,15 @@ describe('get-type', () => {
 				direction: 'outgoing',
 				hasMany: true,
 			});
+			expect(type.properties.cypherMany).toEqual({
+				isRelationship: true,
+				showInactive: true,
+				writeInactive: false,
+				type: 'Type2',
+				cypher: 'MATCH (this)-[]->(related) RETURN DISTINCT related',
+				hasMany: true,
+			});
 			expect(type.properties.singular).toEqual({
-				isRecursive: false,
 				isRelationship: true,
 				showInactive: true,
 				writeInactive: false,

--- a/packages/schema-sdk/data-accessors/type.js
+++ b/packages/schema-sdk/data-accessors/type.js
@@ -134,14 +134,13 @@ const getType = function(
 
 	if (withRelationships) {
 		Object.entries(typeSchema.properties).forEach(([propName, def]) => {
-			if (def.relationship) {
+			if (def.relationship || def.cypher) {
 				if (def.hidden) {
 					delete typeSchema.properties[propName];
 				}
 				Object.assign(def, {
 					hasMany: def.hasMany || false,
-					isRelationship: !!def.relationship,
-					isRecursive: def.isRecursive || false,
+					isRelationship: !!(def.relationship || def.cypher),
 					writeInactive:
 						'writeInactive' in def ? def.writeInactive : false,
 					showInactive:


### PR DESCRIPTION
# Why
isRecursive was originally intended as syntactic sugar to make it easier for users to add properties which recursively traverse relationships. However
- it's not being used really
- properties defined using isRecursive miss out on the fancy graphql filters
- there are far more use cases for interesting reports which require traversal of larger graphs, but these are rarely following a single type of relationship

For these reasons it's worth deprecating. I am doing this now so that a bit of complexity is removed from the schema before we start to work on enhancing for rich relationships

# What 
- Deprecates isRecursive
- adds a new cypher property that can be defined to indicate that the @cypher directive should be used to retrieve related records using a custom cypher query

Some care needed to be taken to make sure things that have `cypher` defined and not `relationship` are still treated as `isRelationship`. Something to improve on in future maybe