### PR TITLE
Lists

### DIFF
--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -22,6 +22,11 @@ properties:
     type: Word
     description: Word description.
     label: Word label
+  someStringList:
+    type: Word
+    hasMany: true
+    description: String list description
+    label: String list label
   someBoolean:
     type: Boolean
     description: Boolean description.
@@ -30,6 +35,11 @@ properties:
     type: AnEnum
     description: Enum description.
     label: Enum label
+  someMultipleChoice:
+    type: AnEnum
+    hasMany: true
+    description: Multiple choice description
+    label: Multiple choice label
   someInteger:
     type: Int
     description: Int description.

--- a/packages/api-express/index.js
+++ b/packages/api-express/index.js
@@ -30,8 +30,7 @@ const getApp = async (options = {}) => {
 		restPath = '/rest',
 		restMiddlewares = [],
 	} = options;
-	updateConstraintsOnSchemaChange();
-	schema.init();
+
 
 	const router = new express.Router();
 	router.use(contextMiddleware);
@@ -47,7 +46,9 @@ const getApp = async (options = {}) => {
 		listenForSchemaChanges: updateGraphqlApiOnSchemaChange,
 	} = getGraphqlApi(options);
 
+	schema.init();
 	updateGraphqlApiOnSchemaChange();
+	updateConstraintsOnSchemaChange();
 
 	graphqlMethods.forEach(method =>
 		router[method](graphqlPath, graphqlMiddlewares, graphqlHandler),

--- a/packages/api-express/index.js
+++ b/packages/api-express/index.js
@@ -31,7 +31,6 @@ const getApp = async (options = {}) => {
 		restMiddlewares = [],
 	} = options;
 
-
 	const router = new express.Router();
 	router.use(contextMiddleware);
 	router.use(requestId);

--- a/packages/api-graphql/index.js
+++ b/packages/api-graphql/index.js
@@ -8,7 +8,7 @@ const getGraphqlApi = ({ documentStore, republishSchema } = {}) => {
 	let graphqlHandler;
 
 	const updateAPI = () => {
-		console.log('asjkdhkjsa dajs sss1111')
+		console.log('asjkdhkjsa dajs sss1111');
 		try {
 			graphqlHandler = getApolloMiddleware({ documentStore });
 

--- a/packages/api-graphql/index.js
+++ b/packages/api-graphql/index.js
@@ -8,7 +8,6 @@ const getGraphqlApi = ({ documentStore, republishSchema } = {}) => {
 	let graphqlHandler;
 
 	const updateAPI = () => {
-		console.log('asjkdhkjsa dajs sss1111');
 		try {
 			graphqlHandler = getApolloMiddleware({ documentStore });
 

--- a/packages/api-graphql/index.js
+++ b/packages/api-graphql/index.js
@@ -8,12 +8,12 @@ const getGraphqlApi = ({ documentStore, republishSchema } = {}) => {
 	let graphqlHandler;
 
 	const updateAPI = () => {
+		console.log('asjkdhkjsa dajs sss1111')
 		try {
 			graphqlHandler = getApolloMiddleware({ documentStore });
 
 			schemaDidUpdate = true;
 			logger.info({ event: 'GRAPHQL_SCHEMA_UPDATED' });
-
 			if (republishSchema) {
 				sendSchemaToS3('api')
 					.then(() => {

--- a/packages/api-graphql/lib/get-augmented-schema.js
+++ b/packages/api-graphql/lib/get-augmented-schema.js
@@ -36,8 +36,18 @@ const getDocumentResolvers = () => {
 
 const getAugmentedSchema = ({ documentStore }) => {
 	const typeDefs = getGraphqlDefs();
+	console.log([
+			`
+directive @deprecated(
+  reason: String = "No longer supported"
+) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION`,
+		]
+			.concat(typeDefs)
+			.join('\n'))
+
 	// this should throw meaningfully if the defs are invalid;
 	parse(typeDefs.join('\n'));
+
 	const schema = makeAugmentedSchema({
 		typeDefs: [
 			`

--- a/packages/api-graphql/lib/get-augmented-schema.js
+++ b/packages/api-graphql/lib/get-augmented-schema.js
@@ -36,15 +36,6 @@ const getDocumentResolvers = () => {
 
 const getAugmentedSchema = ({ documentStore }) => {
 	const typeDefs = getGraphqlDefs();
-	console.log([
-			`
-directive @deprecated(
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION`,
-		]
-			.concat(typeDefs)
-			.join('\n'))
-
 	// this should throw meaningfully if the defs are invalid;
 	parse(typeDefs.join('\n'));
 

--- a/packages/api-rest-handlers/__tests__/get.spec.js
+++ b/packages/api-rest-handlers/__tests__/get.spec.js
@@ -35,6 +35,20 @@ describe('rest GET', () => {
 		expect(body).toMatchObject(meta.default);
 	});
 
+	it('retrieves array data', async () => {
+		await createMainNode({
+			someStringList: ['one', 'two'],
+			someMultipleChoice: ['First', 'Second']
+		});
+		const { body, status } = await getHandler()(input);
+
+		expect(status).toBe(200);
+		expect(body).toMatchObject({
+			someStringList: ['one', 'two'],
+			someMultipleChoice: ['First', 'Second']
+		});
+	});
+
 	it('gets record with relationships', async () => {
 		const [main, child, parent] = await createNodes(
 			['MainType', mainCode],

--- a/packages/api-rest-handlers/__tests__/get.spec.js
+++ b/packages/api-rest-handlers/__tests__/get.spec.js
@@ -38,14 +38,14 @@ describe('rest GET', () => {
 	it('retrieves array data', async () => {
 		await createMainNode({
 			someStringList: ['one', 'two'],
-			someMultipleChoice: ['First', 'Second']
+			someMultipleChoice: ['First', 'Second'],
 		});
 		const { body, status } = await getHandler()(input);
 
 		expect(status).toBe(200);
 		expect(body).toMatchObject({
 			someStringList: ['one', 'two'],
-			someMultipleChoice: ['First', 'Second']
+			someMultipleChoice: ['First', 'Second'],
 		});
 	});
 

--- a/packages/api-rest-handlers/__tests__/patch-create.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-create.spec.js
@@ -65,7 +65,24 @@ describe('rest PATCH create', () => {
 				.exists()
 				.match(meta.create);
 		});
+		it('sets array data', async () => {
+			const { body, status } = await basicHandler({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second']
+			});
 
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second']
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.match({
+					someStringList: ['one', 'two'],
+					someMultipleChoice: ['First', 'Second']
+				})
+		});
 		it("doesn't set a property when empty string provided", async () => {
 			const { status, body } = await basicHandler({ someString: '' });
 

--- a/packages/api-rest-handlers/__tests__/patch-create.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-create.spec.js
@@ -68,20 +68,20 @@ describe('rest PATCH create', () => {
 		it('sets array data', async () => {
 			const { body, status } = await basicHandler({
 				someStringList: ['one', 'two'],
-				someMultipleChoice: ['First', 'Second']
+				someMultipleChoice: ['First', 'Second'],
 			});
 
-			expect(status).toBe(200);
+			expect(status).toBe(201);
 			expect(body).toMatchObject({
 				someStringList: ['one', 'two'],
-				someMultipleChoice: ['First', 'Second']
+				someMultipleChoice: ['First', 'Second'],
 			});
 			await neo4jTest('MainType', mainCode)
 				.exists()
 				.match({
 					someStringList: ['one', 'two'],
-					someMultipleChoice: ['First', 'Second']
-				})
+					someMultipleChoice: ['First', 'Second'],
+				});
 		});
 		it("doesn't set a property when empty string provided", async () => {
 			const { status, body } = await basicHandler({ someString: '' });

--- a/packages/api-rest-handlers/__tests__/patch-diff.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-diff.spec.js
@@ -39,6 +39,23 @@ describe('rest PATCH diff', () => {
 		);
 	});
 
+		it("doesn't write if no real array property changes detected", async () => {
+		await createMainNode({
+			someStringList: ['one', 'two'],
+			someMultipleChoice: ['First', 'Second']
+		});
+		const dbQuerySpy = spyDbQuery();
+		const { status } = await basicHandler({
+			someStringList: ['two', 'one'],
+			someMultipleChoice: ['Second', 'First']
+		});
+		expect(status).toBe(200);
+		expect(dbQuerySpy()).not.toHaveBeenCalledWith(
+			expect.stringMatching(/MERGE|CREATE/),
+			expect.any(Object),
+		);
+	});
+
 	it("doesn't write if no real relationship changes detected in REPLACE mode", async () => {
 		const [main, child] = await createNodes(
 			['MainType', mainCode],

--- a/packages/api-rest-handlers/__tests__/patch-diff.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-diff.spec.js
@@ -39,15 +39,15 @@ describe('rest PATCH diff', () => {
 		);
 	});
 
-		it("doesn't write if no real array property changes detected", async () => {
+	it("doesn't write if no real array property changes detected", async () => {
 		await createMainNode({
 			someStringList: ['one', 'two'],
-			someMultipleChoice: ['First', 'Second']
+			someMultipleChoice: ['First', 'Second'],
 		});
 		const dbQuerySpy = spyDbQuery();
 		const { status } = await basicHandler({
 			someStringList: ['two', 'one'],
-			someMultipleChoice: ['Second', 'First']
+			someMultipleChoice: ['Second', 'First'],
 		});
 		expect(status).toBe(200);
 		expect(dbQuerySpy()).not.toHaveBeenCalledWith(

--- a/packages/api-rest-handlers/__tests__/patch-update.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-update.spec.js
@@ -74,20 +74,20 @@ describe('rest PATCH update', () => {
 		it('sets array data', async () => {
 			const { body, status } = await basicHandler({
 				someStringList: ['one', 'two'],
-				someMultipleChoice: ['First', 'Second']
+				someMultipleChoice: ['First', 'Second'],
 			});
 
-			expect(status).toBe(200);
+			expect(status).toBe(201);
 			expect(body).toMatchObject({
 				someStringList: ['one', 'two'],
-				someMultipleChoice: ['First', 'Second']
+				someMultipleChoice: ['First', 'Second'],
 			});
 			await neo4jTest('MainType', mainCode)
 				.exists()
 				.match({
 					someStringList: ['one', 'two'],
-					someMultipleChoice: ['First', 'Second']
-				})
+					someMultipleChoice: ['First', 'Second'],
+				});
 		});
 		describe('temporal properties', () => {
 			const neo4jTimePrecision = timestamp =>

--- a/packages/api-rest-handlers/__tests__/patch-update.spec.js
+++ b/packages/api-rest-handlers/__tests__/patch-update.spec.js
@@ -71,6 +71,24 @@ describe('rest PATCH update', () => {
 				.exists()
 				.match(meta.update);
 		});
+		it('sets array data', async () => {
+			const { body, status } = await basicHandler({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second']
+			});
+
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second']
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.match({
+					someStringList: ['one', 'two'],
+					someMultipleChoice: ['First', 'Second']
+				})
+		});
 		describe('temporal properties', () => {
 			const neo4jTimePrecision = timestamp =>
 				timestamp.replace('Z', '000000Z');

--- a/packages/api-rest-handlers/__tests__/post.spec.js
+++ b/packages/api-rest-handlers/__tests__/post.spec.js
@@ -71,6 +71,25 @@ describe('rest POST', () => {
 				.match(meta.create);
 		});
 
+		it('sets array data', async () => {
+			const { body, status } = await basicHandler({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second'],
+			});
+
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				someStringList: ['one', 'two'],
+				someMultipleChoice: ['First', 'Second'],
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.match({
+					someStringList: ['one', 'two'],
+					someMultipleChoice: ['First', 'Second'],
+				});
+		});
+
 		it("doesn't set a property when empty string provided", async () => {
 			const { status, body } = await basicHandler({ someString: '' });
 

--- a/packages/schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/schema-sdk/data-accessors/graphql-defs.js
@@ -32,8 +32,8 @@ ${content}
 
 const maybePluralType = ({ type, hasMany }) => (hasMany ? `[${type}]` : type);
 
-const maybePaginate = ({ hasMany }) =>
-	hasMany ? '(first: Int, offset: Int)' : '';
+const maybePaginate = ({ hasMany, isRelationship }) =>
+	hasMany && isRelationship ? '(first: Int, offset: Int)' : '';
 
 const maybeDirective = def => {
 	if (def.cypher) {
@@ -182,7 +182,7 @@ const getIdentifyingFields = config =>
 
 const getFilteringFields = config =>
 	Object.entries(config.properties).filter(
-		([, { isRelationship }]) => !isRelationship,
+		([, { isRelationship, hasMany }]) => !(isRelationship || hasMany),
 	);
 
 const paginationConfig = {

--- a/packages/schema-sdk/lib/validators.js
+++ b/packages/schema-sdk/lib/validators.js
@@ -92,26 +92,32 @@ const validateProperty = ({ getType, getEnums }) => {
 				exit('Must be a finite integer');
 			}
 		} else if (type === 'String') {
-			if (typeof propertyValue !== 'string') {
-				exit('Must be a string');
-			}
-
-			if (validator && !validator.test(propertyValue)) {
-				const maxlength = validator
-					.toString()
-					.match(/\.\{\d+,(\d+)\}\$/);
-				if (maxlength) {
-					exit(
-						`Must match pattern ${validator} and be no more than ${maxlength[1]} characters`,
-					);
+			const values = hasMany ? propertyValue : [propertyValue];
+			values.forEach(value => {
+				if (typeof value !== 'string') {
+					exit('Must be a string');
 				}
-				exit(`Must match pattern ${validator}`);
-			}
+
+				if (validator && !validator.test(value)) {
+					const maxlength = validator
+						.toString()
+						.match(/\.\{\d+,(\d+)\}\$/);
+					if (maxlength) {
+						exit(
+							`Must match pattern ${validator} and be no more than ${maxlength[1]} characters`,
+						);
+					}
+					exit(`Must match pattern ${validator}`);
+				}
+			});
 		} else if (type in getEnums()) {
+			const values = hasMany ? propertyValue : [propertyValue];
 			const validVals = Object.values(getEnums()[type]);
-			if (!validVals.includes(propertyValue)) {
-				exit(`Must be a valid enum: ${validVals.join(', ')}`);
-			}
+			values.forEach(value => {
+				if (!validVals.includes(value)) {
+					exit(`Must be a valid enum: ${validVals.join(', ')}`);
+				}
+			});
 		}
 	};
 

--- a/packages/schema-validator/tests/types.js
+++ b/packages/schema-validator/tests/types.js
@@ -186,6 +186,7 @@ describe('types', () => {
 									'description',
 									'label',
 									'deprecationReason',
+									'hasMany',
 								];
 								if (fieldsets) {
 									commonKeys.push('fieldset');
@@ -197,7 +198,7 @@ describe('types', () => {
 											commonKeys.concat([
 												'direction',
 												'relationship',
-												'hasMany',
+
 												'useInSummary',
 												'cypher',
 												'hidden',
@@ -329,6 +330,12 @@ describe('types', () => {
 										expect(
 											Array.isArray(config.examples),
 										).toBe(true);
+									}
+								});
+
+								it('may allow many strings or enums', () => {
+									if (config.hasMany) {
+										expect([...validEnums].concat('Word')).toContain(config.type)
 									}
 								});
 							});

--- a/packages/schema-validator/tests/types.js
+++ b/packages/schema-validator/tests/types.js
@@ -335,7 +335,9 @@ describe('types', () => {
 
 								it('may allow many strings or enums', () => {
 									if (config.hasMany) {
-										expect([...validEnums].concat('Word')).toContain(config.type)
+										expect(
+											[...validEnums].concat('Word'),
+										).toContain(config.type);
 									}
 								});
 							});


### PR DESCRIPTION
# Why
It's been a long standing thing on the wishlist to support lists of strings (aka tags) and enums (aka multiple choice) stored in single properties on records. Combining the schema and api in one repo has revealed that this is actually really easy to do. Still the question of UI to solve (which will be harder for the tagging case (though fairly straightforward for multiple choice checkboxes). Not planning on merging this imminently as I don't believe in adding to the api without a plan for UI

# What
hasMany is permissable for enum and word fields in the schema. Once this is done, there's surprisingly little work needed in the apis:
- check for hasMany on all properties, not just rels, when generating graphql schema
- anticipate getting arrays of strings when validating hasMany properties
- diff of array before writing to these properties