### PR TITLE
a few tweaks to test runs, and enable publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,9 @@ jobs:
       - run:
           name: Setup npm credetials
           command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
-      # - run:
-      #     name: Publish to npm registry
-      #     command: make npm-publish
+      - run:
+          name: Publish to npm registry
+          command: make npm-publish
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ deploy-aws:
 	aws cloudformation deploy --stack-name biz-ops-kinesis --template-body file://$(shell pwd)/aws/cloudformation/biz-ops-kinesis.yaml
 
 test:
+	# Make sure db constraints are set up to avoid race conditions between the first two test suites
+	TREECREEPER_SCHEMA_DIRECTORY=example-schema node ./packages/tc-api-db-manager/index.js
 	@if [ -z $(CI) ]; \
 		then TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --watch; \
 		else TREECREEPER_SCHEMA_DIRECTORY=example-schema jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --maxWorkers=2 --ci --reporters=default --reporters=jest-junit; \
@@ -115,7 +117,3 @@ load-test-writeQueriesForTeams:
 
 load-test-cleanUp:
 	node scripts/load-testing/clean-up
-
-s3-publish:
-	@node schema/scripts/deploy
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,6 +631,22 @@
         "@financial-times/n-logger": "^6.1.0"
       }
     },
+    "@financial-times/tc-api-graphql": {
+      "version": "file:packages/tc-api-graphql",
+      "dev": true,
+      "requires": {
+        "@financial-times/n-logger": "^6.1.0",
+        "@financial-times/tc-api-db-manager": "file:packages/tc-api-db-manager",
+        "@financial-times/tc-api-express-logger": "file:packages/tc-api-express-logger",
+        "@financial-times/tc-schema-publisher": "file:packages/tc-schema-publisher",
+        "@financial-times/tc-schema-sdk": "file:packages/tc-schema-sdk",
+        "apollo-server-express": "^2.9.7",
+        "dataloader": "^1.4.0",
+        "graphql": "^14.5.8",
+        "graphql-middleware": "^4.0.2",
+        "neo4j-graphql-js": "^2.8.0"
+      }
+    },
     "@financial-times/tc-api-publish": {
       "version": "file:packages/tc-api-publish",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@financial-times/athloi": "github:ysugimoto/athloi",
     "@financial-times/rel-engage": "^7.2.2",
     "@financial-times/tc-api-rest-handlers": "file:./packages/tc-api-rest-handlers",
+    "@financial-times/tc-api-graphql": "file:./packages/tc-api-graphql",
     "@ljharb/eslint-config": "^15.0.2",
     "artillery": "^1.6.0-28",
     "artillery-plugin-statsd": "^2.2.1",


### PR DESCRIPTION
# Why 
Gearing up to start publishing packages so we can start rolling out treecreeper packages

# What
- enables `make npm-publish`
- creates db constraints before jest starts (to squish some race conditions in tests)
