### PR TITLE
move graphql deprecation directive into schema-sdk

### DIFF
--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -39,14 +39,7 @@ const getAugmentedSchema = ({ documentStore }) => {
 	// this should throw meaningfully if the defs are invalid;
 	parse(typeDefs.join('\n'));
 	const schema = makeAugmentedSchema({
-		typeDefs: [
-			`
-directive @deprecated(
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION`,
-		]
-			.concat(typeDefs)
-			.join('\n'),
+		typeDefs: typeDefs.join('\n'),
 		logger: {
 			log(message) {
 				logger.error(`GraphQL Schema: ${message}`, {

--- a/packages/tc-api-publish-adaptors/package.json
+++ b/packages/tc-api-publish-adaptors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/tc-api-publish-adaptors",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Treecreeper&tm; log publishing adaptor for @financial-times/tc-api-publish",
   "main": "index.js",
   "author": "",

--- a/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
@@ -114,6 +114,10 @@ describe('graphql def creation', () => {
 		expect(generated).toEqual(
 			explodeString(
 				`
+directive @deprecated(
+  reason: String = "No longer supported"
+) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION
+
 scalar DateTime
 scalar Date
 scalar Time

--- a/packages/tc-schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/tc-schema-sdk/data-accessors/graphql-defs.js
@@ -279,7 +279,11 @@ module.exports = {
 		});
 		const enums = this.getEnums({ withMeta: true });
 
-		const temporalTypeDefinitions = stripIndent`
+		const staticTypeDefinitions = stripIndent`
+		directive @deprecated(
+		  reason: String = "No longer supported"
+		) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION
+
 		scalar DateTime
 		scalar Date
 		scalar Time
@@ -295,7 +299,7 @@ module.exports = {
 		const queryDefinition = printQueryDefinitions(types);
 
 		return [].concat(
-			temporalTypeDefinitions,
+			staticTypeDefinitions,
 			typeDefinitions,
 			relationshipTypeDefinitions,
 			queryDefinition,


### PR DESCRIPTION
# Why
It was added to biz-ops-api, rather than schema, a while back when upgrading graphql-js, in order to avoid the api breaking (previous version included deprecated directive by default, new one needed it to be user defined). But this was never the right placce to store it

# What
Prints the deprecated directive at the beginning of the graphQL that schema sdk generates.