### PR TITLE
Fix so republishing always reads data from schema instance

### DIFF
--- a/packages/tc-schema-publisher/index.js
+++ b/packages/tc-schema-publisher/index.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const AWS = require('aws-sdk');
 const { Readable } = require('stream');
+const schema = require('@financial-times/tc-schema-sdk');
 
 const s3Client = new AWS.S3({ region: 'eu-west-1' });
 
@@ -15,13 +16,16 @@ const getVersion = schemaObject => {
 const sendSchemaToS3 = async (
 	environment,
 	bucketName = process.env.TREECREEPER_SCHEMA_BUCKET,
-	schemaObject,
 ) => {
+	await schema.ready();
+	const schemaObject = {
+		...schema.rawData.getAll(),
+	};
 	schemaObject.version = schemaObject.version || getVersion(schemaObject);
-	const schema = JSON.stringify(schemaObject, null, 2);
+	const schemaAsString = JSON.stringify(schemaObject, null, 2);
 
 	const uploadStream = new Readable();
-	uploadStream.push(schema);
+	uploadStream.push(schemaAsString);
 	uploadStream.push(null);
 
 	console.log(

--- a/packages/tc-schema-publisher/scripts/deploy.js
+++ b/packages/tc-schema-publisher/scripts/deploy.js
@@ -35,13 +35,7 @@ const action = async (...args) => {
 		}
 
 		schema.init({ schemaDirectory });
-		await schema.ready();
-
-		const schemaObject = {
-			...schema.rawData.getAll(),
-			version: process.env.CIRCLE_TAG,
-		};
-		await sendSchemaToS3(env, bucketName, schemaObject);
+		await sendSchemaToS3(env, bucketName);
 		console.log('successfully deployed');
 	} catch (err) {
 		console.error('Failed to deploy');


### PR DESCRIPTION
# Why 
This makes it possible for republishing to be more declarative, and easier to use in the gradual roll out of treecreeper things

# What
schema publisher always reads from sdk to get its source data - does not accept a parameter which passes in some data