### PR TITLE
Metrics

### DIFF
--- a/api/server/create-app.js
+++ b/api/server/create-app.js
@@ -1,7 +1,6 @@
 const express = require('express');
 require('express-async-errors');
 const metrics = require('next-metrics');
-const timeout = require('connect-timeout');
 const { getApp } = require('../../packages/tc-api-express');
 // const { createStore } = require('../../packages/tc-api-s3-document-store');
 const health = require('./health');
@@ -38,7 +37,7 @@ const createApp = async () => {
 
 	// Always assign/propagate requestId and setup request tracing
 	app.set('case sensitive routing', true);
-	app.use(timeout(TIMEOUT));
+
 	app.use(security.requireApiKey);
 
 	await getApp({
@@ -52,6 +51,7 @@ const createApp = async () => {
 		schemaOptions: { updateMode: 'poll' },
 		republishSchemaPrefix: 'api',
 		republishSchema: true,
+		timeout: TIMEOUT,
 		// documentStore: createStore(),
 	}).then(() => {
 		app.use(errorToErrors);

--- a/api/server/create-app.js
+++ b/api/server/create-app.js
@@ -40,14 +40,15 @@ const createApp = async () => {
 	app.set('case sensitive routing', true);
 	app.use(timeout(TIMEOUT));
 	app.use(security.requireApiKey);
-	app.use(maintenance.disableWrites);
-	app.use(maintenance.disableReads);
 
 	await getApp({
 		app,
+		graphqlPath: '/graphql',
 		graphqlMethods: ['post', 'get'],
+		graphqlMiddlewares: [maintenance.disableReads],
 		restPath: '/v2/node',
 		restMethods: ['HEAD', 'POST', 'DELETE', 'PATCH', 'ABSORB'],
+		restMiddlewares: [maintenance.disableReads, maintenance.disableWrites],
 		schemaOptions: { updateMode: 'poll' },
 		republishSchemaPrefix: 'api',
 		republishSchema: true,

--- a/api/server/middleware/errors.js
+++ b/api/server/middleware/errors.js
@@ -2,9 +2,6 @@ const { logger } = require('../../../packages/tc-api-express-logger');
 
 // eslint-disable-next-line no-unused-vars
 const errorToErrors = (err, req, res, next) => {
-	if (process.env.DEBUG) {
-		console.log(err); // eslint-disable-line no-console
-	}
 	logger.error({ event: 'BIZ_OPS_API_ERROR', error: err });
 
 	if (!err.status) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "body-parser": "^1.19.0",
     "clone": "^2.1.2",
     "common-tags": "^1.8.0",
-    "connect-timeout": "^1.9.0",
     "dataloader": "^1.4.0",
     "deep-diff": "^1.0.2",
     "deep-freeze": "0.0.1",

--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -2,7 +2,10 @@ const neo4j = require('neo4j-driver').v1;
 const metrics = require('next-metrics');
 const { logger } = require('@financial-times/tc-api-express-logger');
 
-const { TIMEOUT } = { TIMEOUT: 15000 };
+let TIMEOUT;
+
+const timeoutErrorMessage = timeout =>
+	`Neo4j query took more than ${timeout} milliseconds: closing session`;
 
 const driver = neo4j.driver(
 	process.env.NEO4J_BOLT_URL,
@@ -15,6 +18,16 @@ const driver = neo4j.driver(
 
 const originalSession = driver.session;
 
+const getTimeoutRacePromise = timeout =>
+	new Promise((res, rej) => {
+		setTimeout(
+			() =>
+				// note that this will cause the finally block to run, which closes the session
+				rej(new Error(timeoutErrorMessage(timeout))),
+			TIMEOUT,
+		);
+	});
+
 driver.session = (...sessionArgs) => {
 	const session = originalSession.apply(driver, sessionArgs);
 	const originalRun = session.run;
@@ -24,21 +37,10 @@ driver.session = (...sessionArgs) => {
 		metrics.count('neo4j.query.count');
 		let isSuccessful = false;
 		try {
-			const result = await Promise.race([
-				originalRun.apply(session, runArgs),
-				new Promise((res, rej) => {
-					setTimeout(
-						() =>
-							// note that this will cause the finally block to run, which closes the session
-							rej(
-								new Error(
-									'Neo4j query took more than 15 seconds: closing session',
-								),
-							),
-						TIMEOUT,
-					);
-				}),
-			]);
+			const dbCall = originalRun.apply(session, runArgs);
+			const result = TIMEOUT
+				? await Promise.race([dbCall, getTimeoutRacePromise(TIMEOUT)])
+				: dbCall;
 
 			isSuccessful = true;
 			return result;
@@ -62,6 +64,9 @@ driver.session = (...sessionArgs) => {
 
 module.exports = {
 	driver,
+	setDbQueryTimeout: timeout => {
+		TIMEOUT = timeout;
+	},
 	executeQuery: (query, parameters) =>
 		driver.session().run(query, parameters),
 	executeQueryWithSharedSession: (session = driver.session()) => {

--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -64,7 +64,7 @@ driver.session = (...sessionArgs) => {
 
 module.exports = {
 	driver,
-	setDbQueryTimeout: timeout => {
+	setTimeout: timeout => {
 		TIMEOUT = timeout;
 	},
 	executeQuery: (query, parameters) =>

--- a/packages/tc-api-express-logger/index.js
+++ b/packages/tc-api-express-logger/index.js
@@ -65,6 +65,7 @@ const logger = new Proxy(nLogger, {
 
 const collectRequestMetrics = (context, res) => {
 	context = context || getContext();
+	res.nextMetricsName = `${context.endpoint}_${context.type}`;
 	logger.info(
 		`Request to ${context.path} completed with status ${res.statusCode}`,
 		{

--- a/packages/tc-api-express/README.md
+++ b/packages/tc-api-express/README.md
@@ -20,7 +20,8 @@ getApp({
 	documentStore, // an [optional] reference to a documentStore object, used to store large properties outside the neo4j instance
 	republishSchema, // a boolean indicating whether the application needs to republish the schema to somewhere once it has updated the graphqlApi
 	republishSchemaPrefix = 'api', // If the application needs to republish the schema to somewhere once it has updated the graphqlApi, this string indicaytes the prefix to use
-	logger // an [optional] logger that implements debug, info, warning and error methods
+	logger, // an [optional] logger that implements debug, info, warning and error methods
+	timeout // optional integer to set maximum time DB will be queried for adn, by association, maximum time a request can stay alive for before being rejected and erroring
 })
 ```
 

--- a/packages/tc-api-express/index.js
+++ b/packages/tc-api-express/index.js
@@ -20,6 +20,8 @@ const bodyParsers = [
 	bodyParser.urlencoded({ limit: '8mb', extended: true }),
 ];
 
+const {requestLog} = require('./lib/request-log');
+
 const getApp = async (options = {}) => {
 	const {
 		app = express(),
@@ -47,7 +49,10 @@ const getApp = async (options = {}) => {
 	} = getGraphqlApi(options);
 
 	graphqlMethods.forEach(method =>
-		router[method](graphqlPath, graphqlMiddlewares, graphqlHandler),
+		router[method](graphqlPath, graphqlMiddlewares, (req, res, next) => {
+			requestLog('graphql', req.method.toUpperCase(), req);
+			next()
+		},graphqlHandler),
 	);
 
 	app.use(treecreeperPath, router);

--- a/packages/tc-api-express/lib/get-rest-api.js
+++ b/packages/tc-api-express/lib/get-rest-api.js
@@ -15,16 +15,7 @@ const {
 
 const { errorToErrors } = require('../middleware/errors');
 
-const requestLog = (endpointName, method, req) => {
-	setContext({
-		endpointName,
-		method,
-		params: req.params,
-		query: req.query,
-		bodyKeys: Object.keys(req.body || {}),
-	});
-	logger.info(`[APP] ${endpointName} ${method}`);
-};
+const {requestLog} = require('./request-log')
 
 const allowedMethodsMiddleware = allowedRestMethods => (req, res, next) => {
 	let appMethod = req.method.toUpperCase();

--- a/packages/tc-api-express/lib/get-rest-api.js
+++ b/packages/tc-api-express/lib/get-rest-api.js
@@ -1,10 +1,6 @@
 const httpErrors = require('http-errors');
 const express = require('express');
 const {
-	logger,
-	setContext,
-} = require('@financial-times/tc-api-express-logger');
-const {
 	headHandler,
 	getHandler,
 	deleteHandler,
@@ -15,7 +11,7 @@ const {
 
 const { errorToErrors } = require('../middleware/errors');
 
-const {requestLog} = require('./request-log')
+const { requestLog } = require('./request-log');
 
 const allowedMethodsMiddleware = allowedRestMethods => (req, res, next) => {
 	let appMethod = req.method.toUpperCase();

--- a/packages/tc-api-express/lib/request-log.js
+++ b/packages/tc-api-express/lib/request-log.js
@@ -1,6 +1,8 @@
+const {
 	logger,
 	setContext,
 } = require('@financial-times/tc-api-express-logger');
+
 const requestLog = (endpointName, method, req) => {
 	setContext({
 		endpointName,
@@ -12,4 +14,4 @@ const requestLog = (endpointName, method, req) => {
 	logger.info(`[APP] ${endpointName} ${method}`);
 };
 
-module.exports = {requestLog}
+module.exports = { requestLog };

--- a/packages/tc-api-express/lib/request-log.js
+++ b/packages/tc-api-express/lib/request-log.js
@@ -1,0 +1,15 @@
+	logger,
+	setContext,
+} = require('@financial-times/tc-api-express-logger');
+const requestLog = (endpointName, method, req) => {
+	setContext({
+		endpointName,
+		method,
+		params: req.params,
+		query: req.query,
+		bodyKeys: Object.keys(req.body || {}),
+	});
+	logger.info(`[APP] ${endpointName} ${method}`);
+};
+
+module.exports = {requestLog}

--- a/packages/tc-api-express/middleware/errors.js
+++ b/packages/tc-api-express/middleware/errors.js
@@ -2,9 +2,6 @@ const { logger } = require('@financial-times/tc-api-express-logger');
 
 // eslint-disable-next-line no-unused-vars
 const errorToErrors = (err, req, res, next) => {
-	if (process.env.DEBUG) {
-		console.log(err); // eslint-disable-line no-console
-	}
 	logger.error({ event: 'BIZ_OPS_API_ERROR', error: err });
 
 	if (!err.status) {

--- a/packages/tc-api-express/package.json
+++ b/packages/tc-api-express/package.json
@@ -11,6 +11,7 @@
     "@financial-times/tc-api-rest-handlers": "file:../tc-api-rest-handlers",
     "@financial-times/tc-schema-sdk": "file:../tc-schema-sdk",
     "body-parser": "^1.19.0",
+    "connect-timeout": "^1.9.0",
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
     "http-errors": "^1.7.3",


### PR DESCRIPTION
# Why
Part of the drive to achieve parity with existing api

# What
- Initialises metrics in a similar way to the existing api. This is not the final intended implementation, but can evolve later
- makes timeout configurable at the app level
- uses slight variations of maintenance middleware on different endpoints