### PR TITLE
Run absorb with transaction

### DIFF
--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -90,7 +90,7 @@ module.exports = {
 
 		return executeQuery;
 	},
-	executeQueryWithTransaction: async (...queries) => {
+	executeQueriesWithTransaction: async (...queries) => {
 		const session = originalSession.apply(driver, []);
 		const result = await session.writeTransaction(async tx =>
 			Promise.all(

--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -15,48 +15,61 @@ const driver = neo4j.driver(
 
 const originalSession = driver.session;
 
+const runQueryWithMetrics = async ({
+	session,
+	runner,
+	isTransaction = false,
+}) => {
+	const start = Date.now();
+	metrics.count('neo4j.query.count');
+	let isSuccessful = false;
+	try {
+		const result = await Promise.race([
+			runner(),
+			new Promise((res, rej) => {
+				setTimeout(
+					() =>
+						// note that this will cause the finally block to run, which closes the session
+						rej(
+							new Error(
+								'Neo4j query took more than 15 seconds: closing session',
+							),
+						),
+					TIMEOUT,
+				);
+			}),
+		]);
+
+		isSuccessful = true;
+		return result;
+	} finally {
+		if (!isTransaction) {
+			session.close();
+		}
+		const totalTime = Date.now() - start;
+		const metricPrefix = `neo4j.query.${
+			isSuccessful ? 'success' : 'failure'
+		}`;
+		metrics.histogram(`${metricPrefix}.time`, totalTime);
+		metrics.count(`${metricPrefix}.count`);
+		logger.info({
+			event: 'NEO4J_QUERY',
+			successful: isSuccessful,
+			totalTime,
+		});
+	}
+};
+
 driver.session = (...sessionArgs) => {
 	const session = originalSession.apply(driver, sessionArgs);
 	const originalRun = session.run;
 
-	session.run = async (...runArgs) => {
-		const start = Date.now();
-		metrics.count('neo4j.query.count');
-		let isSuccessful = false;
-		try {
-			const result = await Promise.race([
-				originalRun.apply(session, runArgs),
-				new Promise((res, rej) => {
-					setTimeout(
-						() =>
-							// note that this will cause the finally block to run, which closes the session
-							rej(
-								new Error(
-									'Neo4j query took more than 15 seconds: closing session',
-								),
-							),
-						TIMEOUT,
-					);
-				}),
-			]);
+	session.run = async (...runArgs) =>
+		runQueryWithMetrics({
+			session,
+			runner: () => originalRun.apply(session, runArgs),
+		});
 
-			isSuccessful = true;
-			return result;
-		} finally {
-			session.close();
-			const totalTime = Date.now() - start;
-			const metricPrefix = `neo4j.query.${
-				isSuccessful ? 'success' : 'failure'
-			}`;
-			metrics.histogram(`${metricPrefix}.time`, totalTime);
-			metrics.count(`${metricPrefix}.count`);
-			logger.info({
-				event: 'NEO4J_QUERY',
-				successful: isSuccessful,
-				totalTime,
-			});
-		}
-	};
 	return session;
 };
 
@@ -72,5 +85,21 @@ module.exports = {
 		executeQuery.close = () => session.close();
 
 		return executeQuery;
+	},
+	executeQueryWithTransaction: async (...queries) => {
+		const session = originalSession.apply(driver, []);
+		const result = await session.writeTransaction(async tx =>
+			Promise.all(
+				queries.map(({ query, parameters }) =>
+					runQueryWithMetrics({
+						session,
+						runner: () => tx.run(query, parameters),
+						isTransaction: true,
+					}),
+				),
+			),
+		);
+		session.close();
+		return result;
 	},
 };

--- a/packages/tc-api-rest-handlers/absorb.js
+++ b/packages/tc-api-rest-handlers/absorb.js
@@ -4,7 +4,7 @@ const { logChanges } = require('@financial-times/tc-api-publish');
 const { getType } = require('@financial-times/tc-schema-sdk');
 const {
 	executeQuery,
-	executeQueryWithTransaction,
+	executeQueriesWithTransaction,
 } = require('./lib/neo4j-model');
 const { validateInput, validateCode } = require('./lib/validation');
 const { diffProperties } = require('./lib/diff-properties');
@@ -215,7 +215,7 @@ const absorbHandler = ({ documentStore } = {}) => async input => {
 
 		// Entire queries which affects current node should run in transaction.
 		// So we stack queries and execute all at once
-		const results = await executeQueryWithTransaction(...queries);
+		const results = await executeQueriesWithTransaction(...queries);
 
 		// Merged result always exists at last index
 		result = results.pop();

--- a/packages/tc-api-rest-handlers/lib/neo4j-model.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-model.js
@@ -1,7 +1,7 @@
 const { getType } = require('@financial-times/tc-schema-sdk');
 const {
 	executeQuery,
-	executeQueryWithTransaction,
+	executeQueriesWithTransaction,
 } = require('@financial-times/tc-api-db-manager');
 const { convertNeo4jToJson } = require('./neo4j-type-conversion');
 
@@ -124,8 +124,8 @@ const addBizOpsEnhancements = result => {
 module.exports = {
 	executeQuery: async (query, params) =>
 		addBizOpsEnhancements(await executeQuery(query, params)),
-	executeQueryWithTransaction: async (...queries) => {
-		const results = await executeQueryWithTransaction(...queries);
+	executeQueriesWithTransaction: async (...queries) => {
+		const results = await executeQueriesWithTransaction(...queries);
 		return results.map(addBizOpsEnhancements);
 	},
 };

--- a/packages/tc-api-rest-handlers/lib/neo4j-model.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-model.js
@@ -1,5 +1,8 @@
 const { getType } = require('@financial-times/tc-schema-sdk');
-const { executeQuery } = require('@financial-times/tc-api-db-manager');
+const {
+	executeQuery,
+	executeQueryWithTransaction,
+} = require('@financial-times/tc-api-db-manager');
 const { convertNeo4jToJson } = require('./neo4j-type-conversion');
 
 const invertDirection = direction =>
@@ -118,5 +121,11 @@ const addBizOpsEnhancements = result => {
 	return result;
 };
 
-module.exports.executeQuery = async (query, params) =>
-	addBizOpsEnhancements(await executeQuery(query, params));
+module.exports = {
+	executeQuery: async (query, params) =>
+		addBizOpsEnhancements(await executeQuery(query, params)),
+	executeQueryWithTransaction: async (...queries) => {
+		const results = await executeQueryWithTransaction(...queries);
+		return results.map(addBizOpsEnhancements);
+	},
+};


### PR DESCRIPTION
## Why

In `absorb` handler, we should execute queries in a transaction in order to rollback the absorbed node and removed relationships

## What

I add the `executeQueryWithTransaction` function and export it via `tc-api-db-manager`, and `tc-api-rest-handlers` use it.

In order to run multiple queries at once in same transaction scope, I declared `executeQueryWithTransaction()`  signature which accepts multiple query sets and return results as an array. see below of usage -- it is wrapped via `neo4j-model.js` to add biz ops enhancements.

```
// in tc-api-rest-handlers
const { executeQueryWithTransaction } = require('./libs/neo4j-model');

const transQueries = [
  { query: 'SOME DELETE QUERY', parameters: {...} },
  { query: 'SOME MERGE QUERY', parameters: {...} },
];

const [deleteResult, mergeResult] = executeQueryWithTransaction(...transQueries);
console.log(mergeResult.toJson({ type: 'MainType', ... });
```

And I adopt this to absorb handler, tests still pass.