### PR TITLE
change REL to rel in graphql

### DIFF
--- a/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
@@ -176,7 +176,7 @@ The groups which are costed to the cost centre
 *NOTE: This gives access to properties on the relationships between records
 as well as on the records themselves. Use 'hasGroups' instead if you do not need this*
 """
-hasGroupsREL(first: Int, offset: Int): [CostcentrePaysForGroup]
+hasGroups_rel(first: Int, offset: Int): [CostcentrePaysForGroup]
 }
 
 """
@@ -235,7 +235,7 @@ The Cost Centre associated with the group
 *NOTE: This gives access to properties on the relationships between records
 as well as on the records themselves. Use 'hasBudget' instead if you do not need this*
 """
-hasBudgetREL: CostcentrePaysForGroup
+hasBudget_rel: CostcentrePaysForGroup
 }
 """
 Internal use only

--- a/packages/tc-schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/tc-schema-sdk/data-accessors/graphql-defs.js
@@ -139,7 +139,7 @@ const buildRichRelationshipPropertyModel = rootType => ([name, def]) => ({
 		${def.description}
 		*NOTE: This gives access to properties on the relationships between records
 		as well as on the records themselves. Use '${name}' instead if you do not need this*`,
-	name: `${name}REL`,
+	name: `${name}_rel`,
 	pagination: maybePaginate(def),
 	type: getRichRelationshipPropertyType(def, rootType),
 	deprecation: maybeDeprecate(def),


### PR DESCRIPTION
# Why
accidentally already released e.g dependenciesREL to prod without intending to. Need to replace with something better ASAP, before anyone starts to query it

# What
Switches REL suffix for _rel in rich relationship properties