### PR TITLE
fix quotation mark bug in graphql

### DIFF
--- a/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
@@ -145,7 +145,7 @@ hasBudget_rel: CostcentrePaysForGroup
 """
 Internal use only
 """
-type CostcentrePaysForGroup @relation(name: PAYS_FOR) {
+type CostcentrePaysForGroup @relation(name: "PAYS_FOR") {
 from: CostCentre
 to: Group
 """

--- a/packages/tc-schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/tc-schema-sdk/data-accessors/graphql-defs.js
@@ -165,7 +165,7 @@ const printRelationshipTypeDefinition = ({
 	return printDescribedBlock(
 		'Internal use only',
 		stripIndent`
-	type ${typeName} @relation(name: ${relationship}) {
+	type ${typeName} @relation(name: "${relationship}") {
 		from: ${from}
 		to: ${to}
 		${propStr}
@@ -297,7 +297,6 @@ module.exports = {
 		scalar Time
 	`;
 		const typeDefinitions = types
-			.filter(({ from, to }) => !from && !to)
 			.map(printTypeDefinition);
 
 		const relationshipTypeDefinitions = printRelationshipTypeDefinitions(

--- a/packages/tc-schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/tc-schema-sdk/data-accessors/graphql-defs.js
@@ -296,8 +296,7 @@ module.exports = {
 		scalar Date
 		scalar Time
 	`;
-		const typeDefinitions = types
-			.map(printTypeDefinition);
+		const typeDefinitions = types.map(printTypeDefinition);
 
 		const relationshipTypeDefinitions = printRelationshipTypeDefinitions(
 			this.getRelationshipTypes({


### PR DESCRIPTION
# Why
Schema currently supports
```
{
  System(code: "biz-ops-api") {
    name
    dependencies_rel {
      System {
        code
      }
    }
  }
}
```

but should support
 
```
{
  System(code: "biz-ops-api") {
    name
    dependencies_rel {
      from {
        System {
          code
        }
      }
    }
  }
}
```

# What
Caused by missing quote marks in the schema, which surprisingly doesn't cause an error, just inaccurate augmentation of the schema