### PR TITLE
created a simple autocomplete endpoint

### DIFF
--- a/demo/api.js
+++ b/demo/api.js
@@ -2,9 +2,11 @@ const express = require('express');
 const expressPlayground = require('graphql-playground-middleware-express')
 	.default;
 const { getApp } = require('../packages/tc-api-express');
+const { autocomplete } = require('./controllers/autocomplete');
 
 const PORT = process.env.PORT || 8888;
 const app = express();
+app.get('/autocomplete/:type/:field', autocomplete);
 app.use(
 	'/graphiql',
 	expressPlayground({

--- a/demo/controllers/autocomplete.js
+++ b/demo/controllers/autocomplete.js
@@ -1,0 +1,74 @@
+const { getType } = require('@financial-times/tc-schema-sdk');
+const fetch = require('node-fetch');
+
+const autocomplete = async (req, res) => {
+	const { field, type } = req.params;
+	const { q, propertyName, parentType } = req.query;
+
+	const targetType = getType(type);
+
+	const query =
+		field in targetType.properties
+			? `OR: [
+					{code_contains: "${q}"},
+					{name_contains: "${q}"}
+				]`
+			: `code_contains: "${q}"`;
+
+	let inactiveQuery = '';
+	if (parentType) {
+		const rootType = getType(parentType);
+		if (rootType.properties[propertyName].addInactive === false) {
+			let { inactiveRule } = targetType;
+			if (!inactiveRule && 'isActive' in targetType.properties) {
+				inactiveRule = { isActive: false };
+			}
+			if (!inactiveRule) return;
+
+			let ruleVal = Object.values(inactiveRule)[0];
+
+			if (typeof ruleVal === 'string') {
+				ruleVal = `"${ruleVal}"`;
+			}
+			inactiveQuery = `, ${Object.keys(inactiveRule)[0]}: ${ruleVal}`;
+		}
+	}
+
+	const graphQlQuery = `{
+		${targetType.pluralName} (
+			filter: {
+				${query}
+				${inactiveQuery}
+			}
+
+		){
+			code
+			${field in targetType.properties ? field : ''}
+		}
+	}`;
+
+	return fetch('http://local.in.ft.com:8888/graphql', {
+		method: 'post',
+		body: JSON.stringify({
+			query: graphQlQuery,
+		}),
+
+		headers: {
+			'client-id': 'rhys',
+			'content-type': 'application/json',
+		},
+	})
+		.then(async response => {
+			if (!response.ok) {
+				const m = await response.text();
+				throw new Error(m);
+			}
+			return response.json();
+		})
+		.then(results => res.json(results.data[targetType.pluralName]))
+		.catch(error => {
+			res.send(error).end();
+		});
+};
+
+module.exports = { autocomplete };


### PR DESCRIPTION
# Why
We can't use our production autocomplete endpoint to work on the relationship editor UI in this repo because the schema is not the same, so autocomplete would never retrieve any results

# What
This implements a simple autocomplete endpoint within the demo app