### PR TITLE
stop fetching deprecated fields for UI

### DIFF
--- a/packages/tc-ui/src/lib/mappers.js
+++ b/packages/tc-ui/src/lib/mappers.js
@@ -45,6 +45,7 @@ const graphqlQueryBuilder = (type, assignComponent) => {
 	query getStuff($itemId: String!) {
     ${type} (code: $itemId) {
     ${Object.entries(getType(type, { includeMetaFields: true }).properties)
+		.filter(([, { deprecationReason }]) => !deprecationReason)
 		.map(([propName, propDef]) =>
 			toGraphql(propName, propDef, assignComponent),
 		)


### PR DESCRIPTION
# Why
I introduced a regression in tc-ui which meant the graphql queries used to build the admin UI have started fetching deprecated fields again

# What
Filters them out before calling graphql