### PR TITLE
reinstate sorting of relationships in UI

### DIFF
--- a/packages/tc-ui/src/primitives/relationship/server.jsx
+++ b/packages/tc-ui/src/primitives/relationship/server.jsx
@@ -15,6 +15,14 @@ const {
 	setRelationshipAnnotator,
 } = require('./lib/view-relationship');
 
+const maybeSort = (hasMany, props) => {
+	if (!hasMany) {
+		return '';
+	}
+	const sortField = props.has('name') ? 'name' : 'code';
+	return `(orderBy: ${sortField}_asc)`;
+};
+
 module.exports = {
 	ViewComponent: ViewRelationship,
 	EditComponent: props => (
@@ -40,7 +48,7 @@ module.exports = {
 	hasValue: (value, { hasMany }) =>
 		hasMany ? value && value.length : !!value,
 	setRelationshipAnnotator,
-	graphqlFragment: (propName, { type }) => {
+	graphqlFragment: (propName, { type, hasMany }) => {
 		const typeDef = getType(type);
 		const props = new Set(['code']);
 		if (typeDef.properties.name) {
@@ -54,6 +62,8 @@ module.exports = {
 			.filter(([, { useInSummary }]) => useInSummary)
 			.forEach(([name]) => props.add(name));
 
-		return `${propName} {${[...props].join(' ')}}`;
+		return `${propName} ${maybeSort(hasMany, props)} {${[...props].join(
+			' ',
+		)}}`;
 	},
 };


### PR DESCRIPTION
# Why
I accidentally dropped it in the move to tc-ui

# What
Added sort to relationship component