### PR TITLE
expose component names

### DIFF
--- a/packages/tc-ui/src/primitives/boolean/server.jsx
+++ b/packages/tc-ui/src/primitives/boolean/server.jsx
@@ -49,6 +49,7 @@ const EditBoolean = props => {
 };
 
 module.exports = {
+	name: 'Boolean',
 	ViewComponent: ({ value, id }) => (
 		<span id={id}>{getBooleanLabel(value)}</span>
 	),

--- a/packages/tc-ui/src/primitives/enum/server.jsx
+++ b/packages/tc-ui/src/primitives/enum/server.jsx
@@ -62,6 +62,7 @@ const EditEnum = props => {
 };
 
 module.exports = {
+	name: 'Enum',
 	ViewComponent: text.ViewComponent,
 	EditComponent: props => (
 		<WrappedEditComponent

--- a/packages/tc-ui/src/primitives/large-text/server.jsx
+++ b/packages/tc-ui/src/primitives/large-text/server.jsx
@@ -39,6 +39,7 @@ const EditLargeText = props => {
 };
 
 module.exports = {
+	name: 'LargeText',
 	EditComponent: props => (
 		<div
 			className={

--- a/packages/tc-ui/src/primitives/number/server.jsx
+++ b/packages/tc-ui/src/primitives/number/server.jsx
@@ -1,6 +1,7 @@
 const text = require('../text/server');
 
 module.exports = {
+	name: 'Number',
 	EditComponent: text.EditComponent,
 	ViewComponent: text.ViewComponent,
 	parser: value => Number(value),

--- a/packages/tc-ui/src/primitives/relationship/server.jsx
+++ b/packages/tc-ui/src/primitives/relationship/server.jsx
@@ -24,6 +24,7 @@ const maybeSort = (hasMany, props) => {
 };
 
 module.exports = {
+	name: 'Relationship',
 	ViewComponent: ViewRelationship,
 	EditComponent: props => (
 		<WrappedEditComponent

--- a/packages/tc-ui/src/primitives/temporal/server.jsx
+++ b/packages/tc-ui/src/primitives/temporal/server.jsx
@@ -59,6 +59,7 @@ const EditTemporal = ({ type, propertyName, value, required, disabled }) => {
 };
 
 module.exports = {
+	name: 'Temporal',
 	EditComponent: props => (
 		<WrappedEditComponent
 			Component={EditTemporal}

--- a/packages/tc-ui/src/primitives/text/server.jsx
+++ b/packages/tc-ui/src/primitives/text/server.jsx
@@ -16,6 +16,7 @@ const EditText = ({ propertyName, value, required, lockedBy, disabled }) => (
 );
 
 module.exports = {
+	name: 'Text',
 	ViewComponent: ({ value, id }) => <span id={id}>{value}</span>,
 	EditComponent: props => (
 		<WrappedEditComponent


### PR DESCRIPTION
# Why
In bits of biz-ops-admin it's useful to know what kind of component we've been allocated in order to decide what data to pass in

# What
Exposes the component name as a property of each component in tc-ui