### PR TITLE
support multiple choice enums in markdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           command: make run-test-db
       - run:
           name: Run tests
-          command: make test
+          command: make init-db test
           environment:
             JEST_JUNIT_OUTPUT: "junit/test-results.xml"
       - store_test_results:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ cypress-verify:
 deploy-aws:
 	aws cloudformation deploy --stack-name biz-ops-kinesis --template-body file://$(shell pwd)/aws/cloudformation/biz-ops-kinesis.yaml
 
-test: init-db
+test:
 	@if [ -z $(CI) ]; \
 		then TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 \
 			jest --config="./jest.config.js" "${pkg}.*__tests__.*/${spec}.*.spec.js" --testEnvironment=node --watch; \

--- a/packages/tc-markdown-parser/lib/markdown-parser.js
+++ b/packages/tc-markdown-parser/lib/markdown-parser.js
@@ -9,7 +9,7 @@ const setTreecreeperPropertyNames = require('./tree-mutators/set-treecreeper-pro
 const coerceTreecreeperPropertiesToType = require('./tree-mutators/coerce-treecreeper-properties-to-type');
 const validateTreecreeperProperties = require('./tree-mutators/validate-treecreeper-properties');
 const stringifyBoast = require('./unist-stringifiers/stringify-boast');
-const setNestedMutlilineProperties = require('./tree-mutators/set-nested-multiline-properties');
+const setNestedMultilineProperties = require('./tree-mutators/set-nested-multiline-properties');
 
 /* @param schema: Treecreeper schema singleton */
 const unifiedProcessor = function({
@@ -41,7 +41,7 @@ const unifiedProcessor = function({
 			.use(setTreecreeperPropertyNames, {
 				properties,
 			})
-			.use(setNestedMutlilineProperties, {
+			.use(setNestedMultilineProperties, {
 				typeNames,
 				properties,
 			})

--- a/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
+++ b/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
@@ -109,7 +109,10 @@ const coerceNestedPropertyValue = (
 	}
 };
 
-const coerceEnumPropertyValue = (node, { propertyType: enumName, hasMany, enums }) => {
+const coerceEnumPropertyValue = (
+	node,
+	{ propertyType: enumName, hasMany, enums },
+) => {
 	let [subdocument] = node.children;
 
 	if (hasMany) {

--- a/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
+++ b/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
@@ -109,7 +109,7 @@ const coerceNestedPropertyValue = (
 	}
 };
 
-const coerceEnumPropertyValue = (node, { propertyType, hasMany, enums }) => {
+const coerceEnumPropertyValue = (node, { propertyType: enumName, hasMany, enums }) => {
 	let [subdocument] = node.children;
 
 	if (hasMany) {
@@ -126,8 +126,6 @@ const coerceEnumPropertyValue = (node, { propertyType, hasMany, enums }) => {
 			message: 'Must provide a single enum, not a nested list',
 		});
 	}
-
-	const enumName = propertyType;
 
 	const validValues = Object.values(enums[enumName]);
 


### PR DESCRIPTION
# Why
We can't support any format of data we want to use in runbooks in the API and UI without also supporting it in the markdown parser. We recently added support for multiple choice enums to the API and UI, so here they are in markdown

# What
Adds the ability for the enum coercer to parse items in a list

## todo
- [ ] add support for multiple choice as properties on relationships