### PR TITLE
clearer error for multi paragraph descriptions in markdown

### DIFF
--- a/packages/tc-markdown-parser/__tests__/first-paragraph.spec.js
+++ b/packages/tc-markdown-parser/__tests__/first-paragraph.spec.js
@@ -68,9 +68,7 @@ test('disallow mutiple description in blocks', async () => {
 	`);
 	expect(errors.length).toBe(1);
 	const [{ message }] = errors;
-	expect(message).toMatch(
-		/Description must be a single paragraph/,
-	);
+	expect(message).toMatch(/Description must be a single paragraph/);
 	expect(data).toMatchObject({
 		name: 'well',
 		description: 'this is first description',

--- a/packages/tc-markdown-parser/__tests__/first-paragraph.spec.js
+++ b/packages/tc-markdown-parser/__tests__/first-paragraph.spec.js
@@ -69,7 +69,7 @@ test('disallow mutiple description in blocks', async () => {
 	expect(errors.length).toBe(1);
 	const [{ message }] = errors;
 	expect(message).toMatch(
-		/only one description is allowed to define in top level/,
+		/Description must be a single paragraph/,
 	);
 	expect(data).toMatchObject({
 		name: 'well',

--- a/packages/tc-markdown-parser/lib/tree-mutators/create-treecreeper-description-node.js
+++ b/packages/tc-markdown-parser/lib/tree-mutators/create-treecreeper-description-node.js
@@ -20,8 +20,7 @@ module.exports = function createBizopsDescriptionNode({
 		if (descriptionChildren.length > 1) {
 			convertNodeToProblem({
 				node: descriptionChildren.pop(),
-				message:
-					'Description must be a single paragraph',
+				message: 'Description must be a single paragraph',
 			});
 		}
 

--- a/packages/tc-markdown-parser/lib/tree-mutators/create-treecreeper-description-node.js
+++ b/packages/tc-markdown-parser/lib/tree-mutators/create-treecreeper-description-node.js
@@ -21,7 +21,7 @@ module.exports = function createBizopsDescriptionNode({
 			convertNodeToProblem({
 				node: descriptionChildren.pop(),
 				message:
-					'only one description is allowed to define in top level',
+					'Description must be a single paragraph',
 			});
 		}
 


### PR DESCRIPTION
# Why
The current error has been reported as confusing

# What
Changed the text. Note that this is on a branch forked from the last 0.3.x release. After releasing a tag on this branch I will merge back in to master