### PR TITLE
adds ability to lock a field globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ deploy-aws:
 test:
 	@if [ -z $(CI) ]; \
 		then TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 \
-			jest --config="./jest.config.js" "${pkg}.*__tests__.*/${spec}.*.spec.js" --testEnvironment=node --watch; \
+			jest --config="./jest.config.js" "${pkg}.*__tests__.*${spec}.*.spec.js" --testEnvironment=node --watch; \
 		else TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
 			jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --maxWorkers=1 --ci --reporters=default --reporters=jest-junit --detectOpenHandles --forceExit; \
 	fi

--- a/demo/cms/index.jsx
+++ b/demo/cms/index.jsx
@@ -31,8 +31,8 @@ const { viewHandler, deleteHandler, editHandler } = getCMS({
 	logger,
 	restApiUrl: 'http://local.in.ft.com:8888/api/rest',
 	graphqlApiUrl: 'http://local.in.ft.com:8888/api/graphql',
+	clientId: 'treecreeper-demo',
 	apiHeaders: ({ metadata: { clientUserId } }) => ({
-		'client-id': 'treecreeper-demo',
 		'client-user-id': clientUserId,
 	}),
 	Subheader,

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -122,7 +122,7 @@ properties:
     label: Curious parent label
   lockedField:
     type: String
-    description: Locked field description
+    description: Locked field description.
     label: Locked field label
     lockedBy:
       - global-lock-client

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -27,8 +27,6 @@ properties:
     description: Word description.
     label: Word label
     useInSummary: true
-    lockedBy:
-      - blah-bler
   # someStringList:
   #   type: Word
   #   hasMany: true
@@ -122,3 +120,9 @@ properties:
     type: CuriousParent
     description: Curious parent description.
     label: Curious parent label
+  lockedField:
+    type: String
+    description: Locked field description
+    label: Locked field label
+    lockedBy:
+      - global-lock-client

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -27,6 +27,8 @@ properties:
     description: Word description.
     label: Word label
     useInSummary: true
+    lockedBy:
+      - blah-bler
   # someStringList:
   #   type: Word
   #   hasMany: true

--- a/packages/tc-api-rest-handlers/__tests__/global-lock.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/global-lock.spec.js
@@ -1,0 +1,100 @@
+const { setupMocks, neo4jTest } = require('../../../test-helpers');
+const { postHandler } = require('../post');
+const { patchHandler } = require('../patch');
+
+describe('global field locking', () => {
+	const namespace = 'global-lock';
+	const mainCode = `${namespace}-main`;
+
+	const { createNode } = setupMocks(namespace);
+
+	const getInput = (body, query, metadata) => ({
+		type: 'MainType',
+		code: mainCode,
+		body,
+		query,
+		metadata,
+	});
+
+	describe('post', () => {
+		it('creates if using correct client', async () => {
+			const { status, body } = await postHandler()(
+				getInput({ lockedField: 'some string' }, undefined, {
+					clientId: 'global-lock-client',
+				}),
+			);
+
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				lockedField: 'some string',
+			});
+
+			expect(body).not.toMatchObject({
+				_lockedFields: expect.any(String),
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.match({
+					lockedField: 'some string',
+				});
+		});
+		it('fails to create if using wrong client', async () => {
+			await expect(
+				postHandler()(
+					getInput({ lockedField: 'some string' }, undefined, {
+						clientId: 'global-lock-client-wrong',
+					}),
+				),
+			).rejects.httpError({
+				status: 400,
+				message:
+					'Cannot write lockedField on MainType global-lock-main - property can only be edited by client global-lock-client',
+			});
+			await neo4jTest('MainType', mainCode).notExists();
+		});
+	});
+
+	describe('patch', () => {
+		it('patches if using correct client', async () => {
+			await createNode('MainType', { code: mainCode });
+			const { status, body } = await patchHandler()(
+				getInput({ lockedField: 'some string' }, undefined, {
+					clientId: 'global-lock-client',
+				}),
+			);
+
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				lockedField: 'some string',
+			});
+
+			expect(body).not.toMatchObject({
+				_lockedFields: expect.any(String),
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.match({
+					lockedField: 'some string',
+				});
+		});
+		it('fails to patch if using wrong client', async () => {
+			await createNode('MainType', { code: mainCode });
+			await expect(
+				patchHandler()(
+					getInput({ lockedField: 'some string' }, undefined, {
+						clientId: 'global-lock-client-incorrect',
+					}),
+				),
+			).rejects.httpError({
+				status: 400,
+				message:
+					'Cannot write lockedField on MainType global-lock-main - property can only be edited by client global-lock-client',
+			});
+			await neo4jTest('MainType', mainCode)
+				.exists()
+				.notMatch({
+					lockedField: 'some string',
+				});
+		});
+	});
+});

--- a/packages/tc-api-rest-handlers/lib/validation.js
+++ b/packages/tc-api-rest-handlers/lib/validation.js
@@ -46,8 +46,7 @@ const validateBody = ({
 		module.exports.validatePropertyName(realPropName);
 		module.exports.validateProperty(type, realPropName, value);
 		const globalLock = properties[realPropName].lockedBy;
-		console.log({ globalLock, clientId });
-		if (globalLock && !globalLock.includes(clientId)) {
+		if (globalLock && (!clientId || !globalLock.includes(clientId))) {
 			throw httpErrors(
 				400,
 				`Cannot write ${realPropName} on ${type} ${code} - property can only be edited by client ${globalLock}`,

--- a/packages/tc-api-rest-handlers/lib/validation.js
+++ b/packages/tc-api-rest-handlers/lib/validation.js
@@ -3,6 +3,7 @@ const { stripIndents } = require('common-tags');
 const {
 	validators,
 	TreecreeperUserError,
+	getType,
 } = require('@financial-times/tc-schema-sdk');
 
 const sdkValidators = Object.entries(validators).reduce(
@@ -27,18 +28,31 @@ const validateParams = ({ type, code }) => {
 	module.exports.validateCode(type, code);
 };
 
-const validateBody = ({ type, code, body: newContent }) => {
+const validateBody = ({
+	type,
+	code,
+	metadata: { clientId } = {},
+	body: newContent,
+}) => {
 	if (newContent.code && newContent.code !== code) {
 		throw httpErrors(
 			400,
 			`Conflicting code property \`${newContent.code}\` in payload for ${type} ${code}`,
 		);
 	}
-
+	const { properties } = getType(type);
 	Object.entries(newContent).forEach(([propName, value]) => {
 		const realPropName = propName.replace(/^!/, '');
 		module.exports.validatePropertyName(realPropName);
 		module.exports.validateProperty(type, realPropName, value);
+		const globalLock = properties[realPropName].lockedBy;
+		console.log({ globalLock, clientId });
+		if (globalLock && !globalLock.includes(clientId)) {
+			throw httpErrors(
+				400,
+				`Cannot write ${realPropName} on ${type} ${code} - property can only be edited by client ${globalLock}`,
+			);
+		}
 	});
 };
 

--- a/packages/tc-schema-validator/MODEL_SPECIFICATION.md
+++ b/packages/tc-schema-validator/MODEL_SPECIFICATION.md
@@ -44,7 +44,7 @@ Each property definition is an object with the following properties
 | useInSummary | no       | `true` on properties named `'code'`, otherwise `false`     | Boolean indicating if the property is considered an essential property to use when constructing a summary of the record. At present, this is used when presenting search results                                                                                                    |                            |
 | pattern      | no       |                                                            | String which is the name of a [string matching pattern]string validation rule](#string-validation-rules).                                                                                                                                                                           | `CODE`, `MAX_LENGTH_64`    |
 
-| lockedBy      | no       |                                                            | Array of strings listing the client-ids that are allowed to edit this field globally                                                                                                                                                                           |     |
+| lockedBy | no | | Array of strings listing the client-ids that are allowed to edit the values stored in this property | |
 
 Note: All existing and any new properties, except for relationships, will automatically have the functionality to be filtered.
 

--- a/packages/tc-schema-validator/MODEL_SPECIFICATION.md
+++ b/packages/tc-schema-validator/MODEL_SPECIFICATION.md
@@ -44,6 +44,8 @@ Each property definition is an object with the following properties
 | useInSummary | no       | `true` on properties named `'code'`, otherwise `false`     | Boolean indicating if the property is considered an essential property to use when constructing a summary of the record. At present, this is used when presenting search results                                                                                                    |                            |
 | pattern      | no       |                                                            | String which is the name of a [string matching pattern]string validation rule](#string-validation-rules).                                                                                                                                                                           | `CODE`, `MAX_LENGTH_64`    |
 
+| lockedBy      | no       |                                                            | Array of strings listing the client-ids that are allowed to edit this field globally                                                                                                                                                                           |     |
+
 Note: All existing and any new properties, except for relationships, will automatically have the functionality to be filtered.
 
 ### Primitive types

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -57,6 +57,7 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 						'label',
 						'deprecationReason',
 						'hasMany',
+						'lockedBy',
 					];
 					if (fieldsets) {
 						commonKeys.push('fieldset');
@@ -130,6 +131,15 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 				if (config.deprecationReason) {
 					expect(typeof config.deprecationReason).toBe('string');
 					expect(config.deprecationReason).not.toMatch(/\n/);
+				}
+			});
+
+			it('has valid lockedBy entry', () => {
+				if (config.lockedBy) {
+					expect(Array.isArray(config.lockedBy)).toBe(true);
+					config.lockedBy.forEach(clientId =>
+						expect(typeof clientId).toBe('string'),
+					);
 				}
 			});
 

--- a/packages/tc-ui/README.md
+++ b/packages/tc-ui/README.md
@@ -58,7 +58,7 @@ String to send to the API as the `Client-Id` header
 
 Either:
 
--   Function that is passed the object received as input, and should return an object containing additional headers to use when calling the treecreeper endpoints e.g. `api-key`, `client-user-id`.
+-   Function that is passed the object received as input, and should return an object containing additional headers to use when calling the treecreeper endpoints e.g. `Api-Key`, `Client-User-Id`.
 -   An object to be use directly as the headers
 
 ##### Subheader

--- a/packages/tc-ui/README.md
+++ b/packages/tc-ui/README.md
@@ -50,9 +50,15 @@ Base url for the treecreeper REST api
 
 Base url for the treecreeper GraphQL api
 
+##### clientId
+
+String to send to the API as the `Client-Id` header
+
 ##### apiHeaders
 
-Function that is passed the object received as input, and should return an object containing the headers to use when calling the treecreeper endpoints
+Either:
+- Function that is passed the object received as input, and should return an object containing additional headers to use when calling the treecreeper endpoints e.g. `api-key`, `client-user-id`.
+- An object to be use directly as the headers
 
 ##### Subheader
 

--- a/packages/tc-ui/README.md
+++ b/packages/tc-ui/README.md
@@ -57,8 +57,9 @@ String to send to the API as the `Client-Id` header
 ##### apiHeaders
 
 Either:
-- Function that is passed the object received as input, and should return an object containing additional headers to use when calling the treecreeper endpoints e.g. `api-key`, `client-user-id`.
-- An object to be use directly as the headers
+
+-   Function that is passed the object received as input, and should return an object containing additional headers to use when calling the treecreeper endpoints e.g. `api-key`, `client-user-id`.
+-   An object to be use directly as the headers
 
 ##### Subheader
 

--- a/packages/tc-ui/src/lib/api-client.js
+++ b/packages/tc-ui/src/lib/api-client.js
@@ -14,7 +14,7 @@ class ApiClient {
 				? this.apiHeaders(this.event)
 				: this.apiHeaders;
 
-		headers['client-id'] = this.clientId,
+		headers['client-id'] = this.clientId;
 		return {
 			'content-type': 'application/json',
 			...headers,

--- a/packages/tc-ui/src/lib/api-client.js
+++ b/packages/tc-ui/src/lib/api-client.js
@@ -13,6 +13,8 @@ class ApiClient {
 			typeof this.apiHeaders === 'function'
 				? this.apiHeaders(this.event)
 				: this.apiHeaders;
+
+		headers['client-id'] = this.clientId,
 		return {
 			'content-type': 'application/json',
 			...headers,

--- a/packages/tc-ui/src/lib/get-data-transformers.js
+++ b/packages/tc-ui/src/lib/get-data-transformers.js
@@ -21,6 +21,13 @@ const getDataTransformers = assignComponent => {
 				) {
 					return;
 				}
+
+				if (
+					fieldProps.lockedBy &&
+					!fieldProps.lockedBy.includes('biz-ops-admin')
+				) {
+					return;
+				}
 				const { parser } = assignComponent(fieldProps);
 
 				const valueHasBeenReceived = fieldName in formData;

--- a/packages/tc-ui/src/lib/get-data-transformers.js
+++ b/packages/tc-ui/src/lib/get-data-transformers.js
@@ -1,6 +1,6 @@
 const schema = require('@financial-times/tc-schema-sdk');
 
-const getDataTransformers = assignComponent => {
+const getDataTransformers = (assignComponent, clientId) => {
 	const formDataToRest = (type, formData) => {
 		const data = {};
 		const typeProperties = schema.getType(type);
@@ -17,14 +17,14 @@ const getDataTransformers = assignComponent => {
 
 				if (
 					lockedFields[fieldName] &&
-					lockedFields[fieldName] !== 'biz-ops-admin'
+					lockedFields[fieldName] !== clientId
 				) {
 					return;
 				}
 
 				if (
 					fieldProps.lockedBy &&
-					!fieldProps.lockedBy.includes('biz-ops-admin')
+					!fieldProps.lockedBy.includes(clientId)
 				) {
 					return;
 				}

--- a/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
+++ b/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
@@ -10,7 +10,7 @@ const {
 	pickChild,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - delete record', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
@@ -14,7 +14,8 @@ const {
 	visitEditPage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+	setLockedRecord,
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - edit record', () => {
 	beforeEach(() => {
@@ -276,5 +277,19 @@ describe('End-to-end - edit record', () => {
 			'have.text',
 			'12 November 2022, 7:00:00 PM',
 		);
+	});
+
+	it('can save record with locked fields', () => {
+		setLockedRecord(code);
+		visitEditPage();
+		cy.get('#id-lockedField').should('have.value', 'locked value 1');
+		cy.get('#id-someString').should('have.value', 'locked value 2');
+		cy.get('#radio-someBoolean-Yes').should('be.checked');
+		save();
+		cy.url().should('contain', `/MainType/${code}`);
+		cy.get('#code').should('have.text', code);
+		cy.get('#lockedField').should('have.text', 'locked value 1');
+		cy.get('#someString').should('have.text', 'locked value 2');
+		cy.get('#someBoolean').should('have.text', 'Yes');
 	});
 });

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -46,7 +46,7 @@ const PropertyInputs = ({ fields, data, isEdit, type, assignComponent }) => {
 				label: name.toUpperCase(),
 				...item,
 				isEdit,
-				lockedBy,
+				lockedBy: item.lockedBy || lockedBy,
 			};
 
 			return viewModel.propertyName && viewModel.label ? (

--- a/packages/tc-ui/src/pages/view/__tests__/e2e-view-complete-record.cyp.js
+++ b/packages/tc-ui/src/pages/view/__tests__/e2e-view-complete-record.cyp.js
@@ -14,7 +14,7 @@ const {
 	populateNonMinimumViableFields,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record creation', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/boolean/__tests__/e2e-record-boolean.cyp.js
+++ b/packages/tc-ui/src/primitives/boolean/__tests__/e2e-record-boolean.cyp.js
@@ -4,7 +4,7 @@ const {
 	visitEditPage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record Boolean type', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/enum/__tests__/e2e-record-enum.cyp.js
+++ b/packages/tc-ui/src/primitives/enum/__tests__/e2e-record-enum.cyp.js
@@ -4,7 +4,7 @@ const {
 	visitEditPage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record Enum type', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/large-text/__tests__/e2e-record-large-text.cyp.js
+++ b/packages/tc-ui/src/primitives/large-text/__tests__/e2e-record-large-text.cyp.js
@@ -7,7 +7,7 @@ const {
 	populateMinimumViableFields,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record LargeText type', () => {
 	it('can record large text', () => {

--- a/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
+++ b/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
@@ -4,7 +4,7 @@ const {
 	visitEditPage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record multiple choice value', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
+++ b/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
@@ -7,7 +7,7 @@ const {
 	populateMinimumViableFields,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record Number type', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-create-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-create-relationships.cyp.js
@@ -10,7 +10,7 @@ const {
 	visitMainTypePage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - relationship creation', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
@@ -8,7 +8,7 @@ const {
 	visitMainTypePage,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - relationship deletion', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
@@ -11,7 +11,7 @@ const {
 	resetDb,
 	setPropsOnCuriousChildRel,
 	setPropsOnCuriousParentRel,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - display relationship properties', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -10,7 +10,7 @@ const {
 	resetDb,
 	setPropsOnCuriousParentRel,
 	setPropsOnCuriousChildRel,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - edit relationship properties', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -8,7 +8,7 @@ const {
 	populateMinimumViableFields,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record Temporal type', () => {
 	beforeEach(() => {

--- a/packages/tc-ui/src/primitives/text/__tests__/e2e-record-text.cyp.js
+++ b/packages/tc-ui/src/primitives/text/__tests__/e2e-record-text.cyp.js
@@ -7,7 +7,7 @@ const {
 	populateMinimumViableFields,
 	save,
 	resetDb,
-} = require('../../../test-helpers');
+} = require('../../../test-helpers/cypress');
 
 describe('End-to-end - record Text type', () => {
 	it('can record a text', () => {

--- a/packages/tc-ui/src/server.js
+++ b/packages/tc-ui/src/server.js
@@ -41,7 +41,7 @@ const getCMS = ({
 
 	const { formDataToRest, formDataToGraphQL } = getDataTransformers(
 		assignComponent,
-		clientId
+		clientId,
 	);
 	const { handler: viewHandler, render: viewRender } = getViewHandler({
 		getApiClient,

--- a/packages/tc-ui/src/server.js
+++ b/packages/tc-ui/src/server.js
@@ -14,6 +14,7 @@ const getCMS = ({
 	logger,
 	restApiUrl,
 	graphqlApiUrl,
+	clientId,
 	apiHeaders,
 	Subheader,
 	customComponents,
@@ -40,6 +41,7 @@ const getCMS = ({
 
 	const { formDataToRest, formDataToGraphQL } = getDataTransformers(
 		assignComponent,
+		clientId
 	);
 	const { handler: viewHandler, render: viewRender } = getViewHandler({
 		getApiClient,

--- a/packages/tc-ui/src/test-helpers/cypress.js
+++ b/packages/tc-ui/src/test-helpers/cypress.js
@@ -163,7 +163,6 @@ const setPropsOnCuriousParentRel = async codeLabel => {
 	});
 };
 
-
 const setLockedRecord = codeLabel => {
 	const query = `MERGE (m:MainType {code: $code})
 		SET m.lockedField = "locked value 1"
@@ -196,5 +195,5 @@ module.exports = {
 	resetDb,
 	setPropsOnCuriousChildRel,
 	setPropsOnCuriousParentRel,
-	setLockedRecord
+	setLockedRecord,
 };

--- a/packages/tc-ui/src/test-helpers/cypress.js
+++ b/packages/tc-ui/src/test-helpers/cypress.js
@@ -132,7 +132,9 @@ const populateNonMinimumViableFields = () => {
 };
 
 const setPropsOnCuriousChildRel = async codeLabel => {
-	const query = `Match(m:MainType)-[r:HAS_CURIOUS_CHILD]->(c:ChildType) where c.code=$code set r.someBoolean =true, r.someString = "lorem ipsum", r.anotherString = "another lorem ipsum", r.someInteger=2020, r.someEnum="First", r.someMultipleChoice = ["First","Third"], r.someFloat = 12.53`;
+	const query = `MATCH (m:MainType)-[r:HAS_CURIOUS_CHILD]->(c:ChildType)
+		WHERE c.code=$code
+		SET r.someBoolean =true, r.someString = "lorem ipsum", r.anotherString = "another lorem ipsum", r.someInteger=2020, r.someEnum="First", r.someMultipleChoice = ["First","Third"], r.someFloat = 12.53`;
 	return new Promise((resolve, reject) => {
 		try {
 			const result = executeQuery(query, {
@@ -146,7 +148,9 @@ const setPropsOnCuriousChildRel = async codeLabel => {
 };
 
 const setPropsOnCuriousParentRel = async codeLabel => {
-	const query = `Match(m:MainType)<-[r:IS_CURIOUS_PARENT_OF]-(c:ParentType) where c.code=$code set r.someString = "parent lorem ipsum", r.anotherString="parent another lorem ipsum"`;
+	const query = `MATCH (m:MainType)<-[r:IS_CURIOUS_PARENT_OF]-(c:ParentType)
+	WHERE c.code=$code
+	SET r.someString = "parent lorem ipsum", r.anotherString="parent another lorem ipsum"`;
 	return new Promise((resolve, reject) => {
 		try {
 			const result = executeQuery(query, {
@@ -158,6 +162,20 @@ const setPropsOnCuriousParentRel = async codeLabel => {
 		}
 	});
 };
+
+
+const setLockedRecord = codeLabel => {
+	const query = `MERGE (m:MainType {code: $code})
+		SET m.lockedField = "locked value 1"
+		SET m.someString = "locked value 2"
+		SET m.someBoolean = true
+		SET m._lockedFields = '{"someString": "lock-client-1", "someBoolean": "lock-client-2"}'
+	RETURN m`;
+	return executeQuery(query, {
+		code: codeLabel,
+	});
+};
+
 const resetDb = async () => {
 	await dropFixtures(code);
 };
@@ -178,4 +196,5 @@ module.exports = {
 	resetDb,
 	setPropsOnCuriousChildRel,
 	setPropsOnCuriousParentRel,
+	setLockedRecord
 };


### PR DESCRIPTION
# Why
GDPR hub have a requirement that some fields on systems relating to GDPR compliance should not be editable via the Biz Ops UI. So we need a mechanism to lock some fields for all records of a given type

# What
- In the schema a field can have a `lockedBy` property, which lists all clients allowed to modify the field
- This is used to validate content submitted to the API
- This is also used to disable inputs in the UI
- Schema validation, api and UI e2e tests now exist for all 3

Also includes a little bit of housekeeping
- renames test-helpers/index.js to test-helpers/cypress.js
- removes the hard coding of the UIs client id as 'biz-ops-admin'

## Checklist
- [x] Schema change 
- [x] Schema documentation
- [x] Schema validation
- [x] API validation
- [x] API tests
- [x] Disable field in UI
- [x] Prevent submitting values from UI
- [x] Write cypress tests