### PR TITLE
more sensible sdk initialisation

### DIFF
--- a/packages/tc-api-express/index.js
+++ b/packages/tc-api-express/index.js
@@ -52,14 +52,13 @@ const getApp = async (options = {}) => {
 	router.use(bodyParsers);
 	router.use(restPath, restMiddlewares, getRestApi(options));
 	router.use(errorToErrors);
-
+	schema.init(schemaOptions);
 	const {
 		isSchemaUpdating,
 		graphqlHandler,
 		listenForSchemaChanges: updateGraphqlApiOnSchemaChange,
 	} = getGraphqlApi(options);
 
-	schema.init();
 	updateGraphqlApiOnSchemaChange();
 	updateConstraintsOnSchemaChange();
 
@@ -83,14 +82,12 @@ const getApp = async (options = {}) => {
 		availableEvents,
 	};
 
-	schema.init(schemaOptions);
 	updateGraphqlApiOnSchemaChange();
 	// avoids this running in every single spec file
 	// instead we explictly set up the constraints once before we start the test suite
 	if (!process.env.TREECREEPER_TEST) {
 		updateConstraintsOnSchemaChange();
 	}
-
 	await schema.ready();
 
 	return app;

--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -14,9 +14,11 @@ In many ways, this is the beating heart of Treecreeper. It consumes the schema f
 The package exports a singleton instance, and once initialised, `@financial-times/biz-ops-schema` can be required multiple times in the application. It should be initialised _once and once only per application_. It also exports a reference to the underlying `SDK` class, but this is only exposed for use by other packages' integration tests.
 
 ### Initialisation
+
 This is a little odd (and should be improved in future)
-- When using local, static data (`schemaDirectory` or `schemaData` options below), the `init()` method populates the sdk with data immediately and its methods can be used to access the data immediately
-- When using remote data (`schemaBaseUrl`), no data is populated, and `schema.ready()` must be awaited before using the sdk's synchronous methods.
+
+-   When using local, static data (`schemaDirectory` or `schemaData` options below), the `init()` method populates the sdk with data immediately and its methods can be used to access the data immediately
+-   When using remote data (`schemaBaseUrl`), no data is populated, and `schema.ready()` must be awaited before using the sdk's synchronous methods.
 
 Be aware of the idiosyncrasy above if oyu ever come across errors complaining that no data is available.
 

--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -20,7 +20,7 @@ This is a little odd (and should be improved in future)
 -   When using local, static data (`schemaDirectory` or `schemaData` options below), the `init()` method populates the sdk with data immediately and its methods can be used to access the data immediately
 -   When using remote data (`schemaBaseUrl`), no data is populated, and `schema.ready()` must be awaited before using the sdk's synchronous methods.
 
-Be aware of the idiosyncrasy above if oyu ever come across errors complaining that no data is available.
+Be aware of the idiosyncrasy above if you ever come across errors complaining that no data is available.
 
 ### `init(options)`
 

--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -14,6 +14,13 @@ In many ways, this is the beating heart of Treecreeper. It consumes the schema f
 The package exports a singleton instance, and once initialised, `@financial-times/biz-ops-schema` can be required multiple times in the application. It should be initialised _once and once only per application_. It also exports a reference to the underlying `SDK` class, but this is only exposed for use by other packages' integration tests.
 
 ### Initialisation
+This is a little odd (and should be improved in future)
+- When using local, static data (`schemaDirectory` or `schemaData` options below), the `init()` method populates the sdk with data immediately and its methods can be used to access the data immediately
+- When using remote data (`schemaBaseUrl`), no data is populated, and `schema.ready()` must be awaited before using the sdk's synchronous methods.
+
+Be aware of the idiosyncrasy above if oyu ever come across errors complaining that no data is available.
+
+### `init(options)`
 
 The package exports an `init(options)` function, that takes the following options:
 

--- a/packages/tc-schema-sdk/browser.js
+++ b/packages/tc-schema-sdk/browser.js
@@ -1,5 +1,5 @@
 const { SDK } = require('./sdk');
 
-module.exports = new SDK({ init: false });
+module.exports = new SDK();
 
 module.exports.SDK = SDK;

--- a/packages/tc-schema-sdk/lib/__tests__/polling.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/polling.spec.js
@@ -8,7 +8,11 @@ const { RawDataWrapper } = require('../raw-data-wrapper');
 const { Cache } = require('../cache');
 
 const create = options =>
-	new SchemaUpdater(options, new RawDataWrapper(), new Cache());
+	new SchemaUpdater({
+		options,
+		rawData: new RawDataWrapper(),
+		cache: new Cache(),
+	});
 
 const nextTick = () => new Promise(res => process.nextTick(res));
 

--- a/packages/tc-schema-sdk/lib/__tests__/stale.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/stale.spec.js
@@ -7,7 +7,11 @@ const { RawDataWrapper } = require('../raw-data-wrapper');
 const { Cache } = require('../cache');
 
 const create = options =>
-	new SchemaUpdater(options, new RawDataWrapper(), new Cache());
+	new SchemaUpdater({
+		options,
+		rawData: new RawDataWrapper(),
+		cache: new Cache(),
+	});
 
 const timer = delay => new Promise(res => setTimeout(res, delay));
 const nextTick = () => new Promise(res => process.nextTick(res));

--- a/packages/tc-schema-sdk/lib/__tests__/validate-code.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/validate-code.spec.js
@@ -1,4 +1,4 @@
-const { SDK } = require('../../sdk');
+const { SDK } = require('../..');
 
 describe('validateCode', () => {
 	const {

--- a/packages/tc-schema-sdk/lib/__tests__/validate-property-name.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/validate-property-name.spec.js
@@ -1,4 +1,4 @@
-const { SDK } = require('../../sdk');
+const { SDK } = require('../..');
 
 describe('validatePropertyName', () => {
 	const {

--- a/packages/tc-schema-sdk/lib/__tests__/validate-property.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/validate-property.spec.js
@@ -1,4 +1,4 @@
-const { SDK } = require('../../sdk');
+const { SDK } = require('../..');
 const readYaml = require('../read-yaml');
 
 const getValidator = (type, { enums, relationshipTypes } = {}) => {

--- a/packages/tc-schema-sdk/lib/__tests__/validate-type-name.spec.js
+++ b/packages/tc-schema-sdk/lib/__tests__/validate-type-name.spec.js
@@ -1,4 +1,4 @@
-const { SDK } = require('../../sdk');
+const { SDK } = require('../..');
 
 describe('validateTypeName', () => {
 	const {

--- a/packages/tc-schema-sdk/lib/updater.js
+++ b/packages/tc-schema-sdk/lib/updater.js
@@ -2,13 +2,15 @@ const EventEmitter = require('events');
 const fetch = require('node-fetch');
 
 class SchemaUpdater {
-	constructor(options, rawData, cache, readYaml) {
+	constructor({ options, rawData, cache, readYaml }) {
 		this.eventEmitter = new EventEmitter();
 		this.lastRefreshDate = 0;
 		this.rawData = rawData;
 		this.cache = cache;
 		this.readYaml = readYaml;
-		this.configure(options);
+		if (options) {
+			this.configure(options);
+		}
 	}
 
 	configure({

--- a/packages/tc-schema-sdk/sdk.js
+++ b/packages/tc-schema-sdk/sdk.js
@@ -25,12 +25,6 @@ class SDK {
 		});
 
 		this.TreecreeperUserError = TreecreeperUserError;
-		this.subscribers = [];
-
-		this.updater.on('change', data => {
-			this.subscribers.forEach(handler => handler(data));
-		});
-
 		this.getEnums = this.createEnrichedAccessor(enums);
 		this.getPrimitiveTypes = this.createEnrichedAccessor(primitiveTypes);
 		this.getStringValidator = this.createEnrichedAccessor(stringValidator);
@@ -78,7 +72,7 @@ class SDK {
 		if (this.rawData.isHydrated) {
 			handler(event);
 		}
-		this.subscribers.push(handler);
+		this.updater.on('change', handler);
 	}
 }
 

--- a/packages/tc-schema-sdk/sdk.js
+++ b/packages/tc-schema-sdk/sdk.js
@@ -14,11 +14,11 @@ const { SchemaUpdater } = require('./lib/updater');
 const utils = require('./lib/utils');
 
 class SDK {
-	constructor(options = {}) {
+	constructor(options) {
 		this.cache = new Cache();
 		this.rawData = new RawDataWrapper();
 		this.updater = new SchemaUpdater({
-			options: options.init !== false ? options : undefined,
+			options,
 			rawData: this.rawData,
 			cache: this.cache,
 			readYaml: this.readYaml,
@@ -51,10 +51,6 @@ class SDK {
 		Object.entries(utils).forEach(([name, method]) => {
 			this[name] = method.bind(this);
 		});
-
-		if (options.init !== false) {
-			this.init(options);
-		}
 	}
 
 	createEnrichedAccessor({ accessor, cacheKeyGenerator }) {
@@ -64,8 +60,8 @@ class SDK {
 		);
 	}
 
-	async init(options) {
-		this.updater.configure(options);
+	init(options) {
+		return this.updater.configure(options);
 	}
 
 	async ready() {

--- a/packages/tc-schema-sdk/sdk.js
+++ b/packages/tc-schema-sdk/sdk.js
@@ -28,7 +28,6 @@ class SDK {
 		this.subscribers = [];
 
 		this.updater.on('change', data => {
-			console.log('change');
 			this.subscribers.forEach(handler => handler(data));
 		});
 
@@ -54,7 +53,6 @@ class SDK {
 		});
 
 		if (options.init !== false) {
-			console.log('init in configure');
 			this.init(options);
 		}
 	}

--- a/packages/tc-schema-sdk/server.js
+++ b/packages/tc-schema-sdk/server.js
@@ -1,5 +1,5 @@
 const { SDK } = require('./sdk');
 SDK.prototype.readYaml = require('./lib/read-yaml');
 
-module.exports = new SDK({ init: false });
+module.exports = new SDK();
 module.exports.SDK = SDK;

--- a/packages/tc-schema-validator/tests/enums.js
+++ b/packages/tc-schema-validator/tests/enums.js
@@ -1,7 +1,9 @@
 /* global it, describe, expect */
 const { SDK } = require('@financial-times/tc-schema-sdk');
 
-const enums = new SDK().rawData.getEnums();
+const sdk = new SDK();
+sdk.init();
+const enums = sdk.rawData.getEnums();
 
 describe('enums', () => {
 	Object.entries(enums).forEach(([name, { description, options }]) => {

--- a/packages/tc-schema-validator/tests/primitive-types.js
+++ b/packages/tc-schema-validator/tests/primitive-types.js
@@ -1,7 +1,9 @@
 /* global it, describe, expect */
 const { SDK } = require('@financial-times/tc-schema-sdk');
 
-const primitiveTypes = new SDK().rawData.getPrimitiveTypes();
+const sdk = new SDK();
+sdk.init();
+const primitiveTypes = sdk.rawData.getPrimitiveTypes();
 
 describe('primitive types', () => {
 	Object.entries(primitiveTypes).forEach(([name, { component, graphql }]) => {

--- a/packages/tc-schema-validator/tests/string-patterns.js
+++ b/packages/tc-schema-validator/tests/string-patterns.js
@@ -1,7 +1,9 @@
 /* global it, describe, expect */
 const { SDK } = require('@financial-times/tc-schema-sdk');
 
-const stringPatterns = new SDK().rawData.getStringPatterns();
+const sdk = new SDK();
+sdk.init();
+const stringPatterns = sdk.rawData.getStringPatterns();
 const longString = 'x'.repeat(257);
 
 describe('string patterns', () => {

--- a/packages/tc-schema-validator/tests/type-hierarchy.js
+++ b/packages/tc-schema-validator/tests/type-hierarchy.js
@@ -2,6 +2,7 @@
 const { SDK } = require('@financial-times/tc-schema-sdk');
 
 const sdk = new SDK();
+sdk.init();
 const { readYaml, rawData } = sdk;
 
 const typeHierarchy = rawData.getTypeHierarchy();

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -3,6 +3,7 @@ const validURL = require('valid-url');
 const { SDK } = require('@financial-times/tc-schema-sdk');
 
 const sdk = new SDK();
+sdk.init();
 const primitiveTypesMap = sdk.getPrimitiveTypes();
 const { getStringValidator } = sdk;
 const enums = sdk.rawData.getEnums();

--- a/packages/tc-schema-validator/tests/types.js
+++ b/packages/tc-schema-validator/tests/types.js
@@ -5,6 +5,7 @@ const { SDK } = require('@financial-times/tc-schema-sdk');
 const { typeTestSuite, relationshipTestSuite } = require('./type-test-suite');
 
 const sdk = new SDK();
+sdk.init();
 const { readYaml } = sdk;
 
 const makePath = dir =>


### PR DESCRIPTION
## Why?

We had a 'fix what annoys you' tech debt day. It annoys me that teh schema-sdk was fussy about whether you've called `init()` before you call `ready()`. This sometimes leads to hard to track down bugs and test failures.

## What?
One of the objects the SDK is composed of is a schema updater, and the `ready()` method is just a proxy through to `this.updater.ready()`. But previously the updater was only created on `init()`, so if `ready()` was called before `init()` you'd get an error. this was a pain because the ready method on the updater was clever enough to handle these sorts of race conditions, just the proxying wasn't.

This PR moves creating the updater into the SDK constructor, and then does a bit of juggling to ensure initialisation only happens when needed. I think it's more or less as sensible as before, but maybe now we're here the path to something more sensible will appear