### PR TITLE
remove biz ops classes and data attributes

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,4 +1,5 @@
 // TODO: move to rel-engage
 module.exports = {
+	"ignoreFiles": ['dist/**/*.css'],
 	extends: ['stylelint-config-recommended-scss'],
 };

--- a/packages/tc-schema-sdk/package.json
+++ b/packages/tc-schema-sdk/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "In many ways, this is the beating heart of Treecreeper&TM;. It consumes the schema files that define what sort of records can be stored in the neo4j instance, and what relationships can exist between them. These schema files may exist locally or be hosted somewhere remote. Once these files are consumed, schema-sdk then takes care of:",
   "main": "server.js",
-  "browser":"browser.js",
+  "browser": "browser.js",
   "author": "",
   "license": "ISC",
   "dependencies": {

--- a/packages/tc-ui/src/lib/components/buttons.jsx
+++ b/packages/tc-ui/src/lib/components/buttons.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
 
-const coreClasses = 'o-buttons o-buttons--big biz-ops-cta';
+const coreClasses = 'o-buttons o-buttons--big treecreeper-cta';
 
 const getButtonClasses = extraClasses =>
 	extraClasses ? `${coreClasses} ${extraClasses}` : coreClasses;
@@ -12,7 +12,7 @@ const EditButton = props => (
 			props.querystring
 		}`}
 		className={getButtonClasses(
-			'o-buttons--primary o-buttons--mono biz-ops-cta--link-style-override',
+			'o-buttons--primary o-buttons--mono treecreeper-cta--link-style-override',
 		)}
 	>
 		Edit
@@ -42,7 +42,7 @@ const CancelButton = props => {
 			data-button-type="cancel"
 			href={redirectLocation}
 			className={getButtonClasses(
-				'o-buttons--mono biz-ops-cta--link-style-override',
+				'o-buttons--mono treecreeper-cta--link-style-override',
 			)}
 		>
 			Cancel
@@ -54,13 +54,13 @@ const DeleteButton = props =>
 	props.isSubset ? null : (
 		<form
 			action={`/${props.type}/${encodeURIComponent(props.code)}/delete`}
-			className="biz-ops-cta"
+			className="treecreeper-cta"
 			method="POST"
 		>
 			<button
 				data-button-type="delete"
 				className={getButtonClasses(
-					'o-buttons--mono biz-ops-cta--delete',
+					'o-buttons--mono treecreeper-cta--delete',
 				)}
 				type="submit"
 			>

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -58,7 +58,7 @@ const WrappedEditComponent = props => {
 	return (
 		<WrapperTag
 			className="o-forms-field"
-			data-biz-ops-type={props.componentType}
+			data-treecreeper-component={props.componentType}
 			data-type={props.dataType}
 			{...(props.wrapperProps || {})}
 		>

--- a/packages/tc-ui/src/lib/components/messages.jsx
+++ b/packages/tc-ui/src/lib/components/messages.jsx
@@ -30,7 +30,7 @@ const Message = ({
 const FormError = props =>
 	props.error ? (
 		<div
-			className="o-message o-message--inner o-message--alert o-message--error biz-ops-alert"
+			className="o-message o-message--inner o-message--alert o-message--error treecreeper-alert"
 			data-o-component="o-message"
 		>
 			<div className="o-message__container">

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -7,7 +7,7 @@ const toKebabCase = string =>
 		.join('-');
 
 const Concept = ({ name, description, moreInformation }) => (
-	<aside className="biz-ops-aside" title="Concept">
+	<aside className="treecreeper-aside" title="Concept">
 		<div className="o-forms-title">
 			<div className="o-forms-title__main">A {name} is:</div>
 			<div className="description-text o-forms-title__prompt">
@@ -31,7 +31,7 @@ const SectionHeader = ({ title, code, type, includeEditLink = false }) => (
 				{includeEditLink && code && type ? (
 					<>
 						<a // eslint-disable-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
-							className="o-icons-icon o-icons-icon--edit biz-ops-section-header__edit-link o-layout__unstyled-element"
+							className="o-icons-icon o-icons-icon--edit treecreeper-section-header__edit-link o-layout__unstyled-element"
 							href={`/${type}/${code}/edit?#${toKebabCase(
 								title,
 							)}`}
@@ -75,12 +75,12 @@ const LabelledPrimitive = props => {
 			>
 				{label}
 				<span
-					className={`tooltip-target-${id} biz-ops-help`}
+					className={`tooltip-target-${id} treecreeper-help`}
 					id={`tooltip-target-${id}`}
 				>
 					<i
 						aria-label={`help for ${id}`}
-						className="o-icons-icon o-icons-icon--info biz-ops-help-icon"
+						className="o-icons-icon o-icons-icon--info treecreeper-help-icon"
 					/>
 				</span>
 				<div

--- a/packages/tc-ui/src/main.css
+++ b/packages/tc-ui/src/main.css
@@ -1,5 +1,5 @@
 /* headings */
-.biz-ops-section-header__edit-link {
+.treecreeper-section-header__edit-link {
 	width: 32px;
 	height: 32px;
 	vertical-align: top;
@@ -11,7 +11,7 @@
 	margin-bottom: 20px;
 }
 
-aside.biz-ops-aside {
+aside.treecreeper-aside {
 	border-left: none;
 }
 
@@ -21,12 +21,12 @@ aside.biz-ops-aside {
 	max-width: 50%;
 }
 
-.biz-ops-help {
+.treecreeper-help {
 	display: inline-block;
 	margin-left: 5px;
 }
 
-.biz-ops-help-icon {
+.treecreeper-help-icon {
 	vertical-align: sub;
 	width: 30px !important;
 	height: 30px !important;
@@ -34,16 +34,16 @@ aside.biz-ops-aside {
 
 /* buttons */
 
-.biz-ops-cta {
+.treecreeper-cta {
 	float: right;
 	margin-left: 8px;
 }
 
-.biz-ops-cta--link-style-override {
+.treecreeper-cta--link-style-override {
 	border: 1px solid black !important;
 }
 
-.biz-ops-cta-container--sticky {
+.treecreeper-cta-container--sticky {
 	position: sticky;
 	top: 10px;
 	z-index: 1;

--- a/packages/tc-ui/src/pages/edit/browser.js
+++ b/packages/tc-ui/src/pages/edit/browser.js
@@ -78,11 +78,11 @@ const preventIncompleteSubmission = () => {
 			.addEventListener('submit', ev => {
 				const essentialFields = [
 					...essentialFieldsFieldset.querySelectorAll(
-						'[data-biz-ops-type]',
+						'[data-treecreeper-component]',
 					),
 				];
 				const unfilledFields = essentialFields.filter(field => {
-					const type = field.dataset.bizOpsType;
+					const type = field.dataset.treecreeperComponent;
 					const checker =
 						fieldValueCheckers[type] || fieldValueCheckers.default;
 					return !checker(field);

--- a/packages/tc-ui/src/pages/edit/main.css
+++ b/packages/tc-ui/src/pages/edit/main.css
@@ -1,5 +1,5 @@
 /* edit page */
-.fieldset-biz-ops {
+.fieldset-treecreeper {
 	margin: 0;
 	padding: 0;
 	border: none;
@@ -11,7 +11,7 @@
 	padding: 10px;
 }
 
-.fieldset-biz-ops .o-forms-field {
+.fieldset-treecreeper .o-forms-field {
 	max-width: 450px;
 }
 /* stylelint-disable */

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -89,7 +89,7 @@ const EditForm = props => {
 						description={schema.description}
 						moreInformation={schema.moreInformation}
 					/>
-					<div className="biz-ops-cta-container--sticky o-layout__unstyled-element">
+					<div className="treecreeper-cta-container--sticky o-layout__unstyled-element">
 						<SaveButton
 							querystring={querystring || ''}
 							type={type}
@@ -104,7 +104,7 @@ const EditForm = props => {
 					{Object.entries(schema.fieldsets).map(
 						([name, { heading, properties }], index) => (
 							<fieldset
-								className={`fieldset-biz-ops fieldset-${name}`}
+								className={`fieldset-treecreeper fieldset-${name}`}
 								key={index}
 							>
 								<div className="o-layout-typography">

--- a/packages/tc-ui/src/pages/view/browser.js
+++ b/packages/tc-ui/src/pages/view/browser.js
@@ -1,7 +1,7 @@
 require('./main.css');
 
 const initDeleteButton = () =>
-	[...document.querySelectorAll('button.biz-ops-cta--delete')].forEach(
+	[...document.querySelectorAll('button.treecreeper-cta--delete')].forEach(
 		button => {
 			button.addEventListener('click', ev => {
 				const response = window.confirm(

--- a/packages/tc-ui/src/pages/view/main.css
+++ b/packages/tc-ui/src/pages/view/main.css
@@ -1,46 +1,46 @@
 /* view page */
 /* classes used in a lot of legacy free-text fields*/
 
-.biz-ops-properties-list {
+.treecreeper-properties-list {
 	margin-bottom: 0;
 }
 
-.biz-ops-properties-list dt {
+.treecreeper-properties-list dt {
 	font-weight: 600;
 	margin-bottom: 0.25rem;
 }
 
-.biz-ops-properties-list dd.inline > *:last-child {
+.treecreeper-properties-list dd.inline > *:last-child {
 	margin-bottom: 0;
 }
 
-.biz-ops-properties-list dd {
+.treecreeper-properties-list dd {
 	margin-left: 0;
 	margin-bottom: 1rem;
 }
 
 @media (min-width: 450px) {
-	.biz-ops-properties-list {
+	.treecreeper-properties-list {
 		display: grid;
 		grid-template-columns: 200px 1fr;
 		grid-column-gap: 1rem;
 		margin-bottom: 0;
 	}
 
-	.biz-ops-properties-list dt.inline {
+	.treecreeper-properties-list dt.inline {
 		grid-column: 1/2;
 	}
-	.biz-ops-properties-list dd.inline {
+	.treecreeper-properties-list dd.inline {
 		grid-column: 2/3;
 	}
-	.biz-ops-properties-list .inline {
+	.treecreeper-properties-list .inline {
 		margin-bottom: 1rem;
 	}
 
-	.biz-ops-properties-list dt.block {
+	.treecreeper-properties-list dt.block {
 		grid-column: 1/3;
 	}
-	.biz-ops-properties-list dd.block {
+	.treecreeper-properties-list dd.block {
 		grid-column: 1/3;
 	}
 }
@@ -60,12 +60,12 @@
 	max-width: 100%;
 }
 
-.biz-ops-links {
+.treecreeper-links {
 	list-style-type: none;
 	padding-left: 0;
 	margin-top: 0;
 }
-.biz-ops-links li {
+.treecreeper-links li {
 	margin-bottom: 0.5em;
 }
 

--- a/packages/tc-ui/src/pages/view/template.jsx
+++ b/packages/tc-ui/src/pages/view/template.jsx
@@ -82,7 +82,7 @@ const View = props => {
 						</div>
 						<Subheader {...props} />
 					</div>
-					<div className="biz-ops-cta-container--sticky">
+					<div className="treecreeper-cta-container--sticky">
 						<EditButton
 							type={schema.type}
 							code={data.code}
@@ -98,7 +98,7 @@ const View = props => {
 						{Object.entries(schema.fieldsets).map(
 							([name, { heading, properties }]) => (
 								<section
-									className={`fieldset-biz-ops fieldset-${name}`}
+									className={`fieldset-treecreeper fieldset-${name}`}
 								>
 									<SectionHeader
 										type={schema.type}
@@ -106,7 +106,7 @@ const View = props => {
 										title={heading}
 										includeEditLink
 									/>
-									<dl className="biz-ops-properties-list">
+									<dl className="treecreeper-properties-list">
 										<Properties
 											fields={properties}
 											data={data}

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -59,9 +59,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 	});
 
 	it('hides fields when Annotate button is clicked, if they are visible', () => {
@@ -77,9 +77,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
@@ -104,9 +104,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -41,7 +41,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 	});
@@ -59,7 +59,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 	});
@@ -77,7 +77,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
@@ -85,7 +85,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 	});
@@ -104,11 +104,11 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.find('#id-someString')
@@ -150,11 +150,11 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
-		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.find('#id-someString')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
@@ -59,16 +59,16 @@ describe('End-to-end - display relationship properties', () => {
 					)
 					.should('be.visible');
 				cy.wrap(parent)
-					.find('.biz-ops-relationship-props-list #someEnum')
+					.find('.treecreeper-relationship-props-list #someEnum')
 					.should('have.text', 'First');
 				cy.wrap(parent)
 					.find(
-						'.biz-ops-relationship-props-list #someMultipleChoice span:first-of-type',
+						'.treecreeper-relationship-props-list #someMultipleChoice span:first-of-type',
 					)
 					.should('have.text', 'First');
 				cy.wrap(parent)
 					.find(
-						'.biz-ops-relationship-props-list #someMultipleChoice span:last-of-type',
+						'.treecreeper-relationship-props-list #someMultipleChoice span:last-of-type',
 					)
 					.should('have.text', 'Third');
 			});
@@ -86,7 +86,7 @@ describe('End-to-end - display relationship properties', () => {
 					)
 					.should('not.be.visible');
 				cy.wrap(child)
-					.find('.biz-ops-relationship-props-list #someEnum')
+					.find('.treecreeper-relationship-props-list #someEnum')
 					.should('not.be.visible');
 			});
 	});
@@ -106,7 +106,7 @@ describe('End-to-end - display relationship properties', () => {
 			.should('have.attr', 'href', `/ChildType/${code}-first-child`);
 		cy.get('#curiousChild')
 			.parent()
-			.get('.biz-ops-relationship-props-list')
+			.get('.treecreeper-relationship-props-list')
 			.then(list => {
 				cy.wrap(list)
 					.find('#someString')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -33,7 +33,7 @@ describe('End-to-end - edit relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 	});
@@ -51,7 +51,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 	});
@@ -69,7 +69,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
@@ -77,7 +77,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 	});
@@ -96,11 +96,11 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.find('#id-someString')
@@ -142,11 +142,11 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
-		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.find('#id-someString')
@@ -170,11 +170,11 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
 			'be.visible',
 		);
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.find('#id-someString')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -51,9 +51,9 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 	});
 
 	it('hides fields when Annotate button is clicked, if they are visible', () => {
@@ -69,9 +69,9 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
@@ -96,9 +96,9 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
@@ -170,9 +170,9 @@ describe('End-to-end - edit relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.click({ force: true });
 
-		cy.get('#ul-curiousChild span.treecreeper-relationship-annotate').should(
-			'be.visible',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/interface.spec.jsx
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/interface.spec.jsx
@@ -20,7 +20,7 @@ describe('relationship interfaces', () => {
 			const wrapper = shallow(<EditComponent {...props} />);
 			expect(
 				wrapper.is(
-					'label.o-forms-field[data-biz-ops-type="relationship"]',
+					'label.o-forms-field[data-treecreeper-component="relationship"]',
 				),
 			).toBe(true);
 			expect(wrapper.children().length).toEqual(2);

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
@@ -68,7 +68,7 @@ class Relationship extends React.Component {
 				<li
 					data-name={value.name}
 					data-code={value.code}
-					className="biz-ops-selected-relationship"
+					className="treecreeper-selected-relationship"
 					key={index}
 				>
 					<span>
@@ -119,7 +119,7 @@ class Relationship extends React.Component {
 					</span>
 					{isMounted && annotate && Object.keys(properties).length ? (
 						<span
-							className="biz-ops-relationship-annotate"
+							className="treecreeper-relationship-annotate"
 							key={index}
 						>
 							<RelationshipProperties

--- a/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
@@ -41,7 +41,7 @@ const OneRelationship = props => {
 					more info
 				</button>
 				<div className="o-expander__content">
-					<dl className="biz-ops-relationship-props-list">
+					<dl className="treecreeper-relationship-props-list">
 						{Object.entries(validValues).map(
 							([name, item], index) => {
 								const viewModel = {
@@ -91,7 +91,7 @@ const ViewRelationship = props => {
 		return datum.isActive === false;
 	};
 	return Array.isArray(value) ? (
-		<ul id={id} className="o-layout__unstyled-element biz-ops-links">
+		<ul id={id} className="o-layout__unstyled-element treecreeper-links">
 			{sortBy(value, [`${type}.code`]).map((item, index) => {
 				return (
 					<li

--- a/packages/tc-ui/src/primitives/relationship/main.css
+++ b/packages/tc-ui/src/primitives/relationship/main.css
@@ -55,58 +55,58 @@
 	position: static !important;
 }
 
-.biz-ops-relationship-props-list {
+.treecreeper-relationship-props-list {
 	margin-top: 0.5em;
 }
 
-.biz-ops-relationship-props-list span {
+.treecreeper-relationship-props-list span {
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0;
 }
 
-.biz-ops-relationship-props-list dt,
-.biz-ops-relationship-props-list dd {
+.treecreeper-relationship-props-list dt,
+.treecreeper-relationship-props-list dd {
 	padding-left: 0.5em;
 	margin-bottom: 0.3em;
 }
 
-.biz-ops-relationship-props-list dd p {
+.treecreeper-relationship-props-list dd p {
 	margin-bottom: 0 !important;
 }
-.biz-ops-relationship-props-list dt {
+.treecreeper-relationship-props-list dt {
 	display: flex;
 }
 
-.biz-ops-relationship-props-list dt:after {
+.treecreeper-relationship-props-list dt:after {
 	content: ':';
 }
 
-.biz-ops-relationship-props-list .biz-ops-help-icon {
+.treecreeper-relationship-props-list .treecreeper-help-icon {
 	display: none;
 }
 
-.biz-ops-selected-relationship {
+.treecreeper-selected-relationship {
 	margin-top: 0;
 	display: grid;
 	grid-auto-flow: row;
 	grid-row-gap: 0.5em;
 }
 
-.biz-ops-selected-relationship > span:first-of-type {
+.treecreeper-selected-relationship > span:first-of-type {
 	display: flex;
 	justify-content: space-between;
 }
 
-.biz-ops-selected-relationship .o-layout-typography {
+.treecreeper-selected-relationship .o-layout-typography {
 	flex-basis: 60%;
 }
 
-.biz-ops-selected-relationship div {
+.treecreeper-selected-relationship div {
 	display: inline;
 }
 
-.biz-ops-relationship-annotate {
+.treecreeper-relationship-annotate {
 	background: var(--o-colors-black-10);
 	padding: 0.5em;
 	margin-left: 1em;


### PR DESCRIPTION
## Why?

Clean up following migration into treecreeper https://trello.com/c/yqI0yQ7Z/289-remove-all-references-to-biz-ops-from-treecreeper

## What?

Basic find and replace throughout tc-ui

### Anything in particular you'd like to highlight to reviewers?

Still need to build up a manual regression list from looking at all the changes. I'm boudn to have broken something.

## Screenshots / Images

Hopefully no difference