### PR TITLE
Improve ux

### DIFF
--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -30,6 +30,7 @@ const PropertyInputs = ({ fields, data, type, assignComponent }) => {
 				: data[propertyName];
 
 			const viewModel = {
+				parentCode: data.code,
 				propertyName,
 				value: getValue(propDef, itemValue),
 				dataType: propDef.type,

--- a/packages/tc-ui/src/primitives/multiple-choice/server.jsx
+++ b/packages/tc-ui/src/primitives/multiple-choice/server.jsx
@@ -9,7 +9,8 @@ const localOnChange = (event, currentValues, onChange) => {
 	const propertyName = id.split('-')[1];
 	// eslint-disable-next-line no-unused-expressions
 	checked ? selectedValues.add(value) : selectedValues.delete(value);
-	onChange(propertyName, parentCode, [...selectedValues].sort());
+	const values = selectedValues.size ? [...selectedValues].sort() : null;
+	onChange(propertyName, parentCode, values);
 };
 
 const Checkbox = ({

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -74,7 +74,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 	});
@@ -82,7 +82,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitEditPage();
 		pickCuriousChild();
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.children()
@@ -94,7 +94,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		pickCuriousParent();
 
-		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').then(
+		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
 				cy.wrap(parent)
 					.children()
@@ -113,7 +113,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
-		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
 			'not.exist',
 		);
 
@@ -138,9 +138,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		visitEditPage();
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
-			'not.exist',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('not.exist');
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
@@ -155,9 +155,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
-		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
-			'not.exist',
-		);
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('not.exist');
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -32,7 +32,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 	});
 
-	it('does not render fields on page load', () => {
+	it('does not show annotation fields on page load', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -46,7 +46,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		);
 	});
 
-	it('renders fields when Annotate button is clicked', () => {
+	it('displays annotation fields when annotation button is clicked', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -57,6 +57,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations')
 			.click({ force: true });
 
 		cy.get(
@@ -64,7 +65,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		).should('be.visible');
 	});
 
-	it('hides fields when Annotate button is clicked, if they are visible', () => {
+	it('hides all existing annotations for existing relationships on page load', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -73,8 +74,52 @@ describe('End-to-end - annotate rich relationship properties', () => {
 		visitMainTypePage();
 		visitEditPage();
 
+		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+			'not.exist',
+		);
+	});
+	it('expands annotations area when adding new relationship', () => {
+		visitEditPage();
+		pickCuriousChild();
+
+		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').then(
+			parent => {
+				cy.wrap(parent)
+					.children()
+					.should('have.length', 7);
+				// someString,anotherString,someInteger,someEnum,
+				// someMultipleChoice,someBoolean,someFloat = 7
+			},
+		);
+
+		pickCuriousParent();
+
+		cy.get('#ul-curiousParent .biz-ops-relationship-annotate').then(
+			parent => {
+				cy.wrap(parent)
+					.children()
+					.should('have.length', 2);
+				// someString,anotherString
+			},
+		);
+	});
+
+	it('disables the annotation button once annotations area is opened', () => {
+		visitEditPage();
+		pickCuriousChild();
+		save();
+
+		cy.wrap().then(() => setPropsOnCuriousChildRel(`${code}-first-child`));
+		visitMainTypePage();
+		visitEditPage();
+
+		cy.get('#ul-curiousChild .biz-ops-relationship-annotate').should(
+			'not.exist',
+		);
+
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations')
 			.click({ force: true });
 
 		cy.get(
@@ -83,11 +128,40 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.click({ force: true });
+			.should('be.disabled');
+	});
 
-		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
+	it('sets label of the button as "Add annotations", if no annotation was done for existing relationships', () => {
+		visitEditPage();
+		pickCuriousChild();
+		save();
+
+		visitEditPage();
+
+		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
 			'not.exist',
 		);
+
+		cy.get('#ul-curiousChild li')
+			.find('button.relationship-annotate-button')
+			.should('have.text', 'Add annotations');
+	});
+	it('sets label of the button as "Edit annotations", if some annotations was done for existing relationships', () => {
+		visitEditPage();
+		pickCuriousChild();
+		save();
+
+		cy.wrap().then(() => setPropsOnCuriousChildRel(`${code}-first-child`));
+		visitMainTypePage();
+		visitEditPage();
+
+		cy.get('#ul-curiousChild span.biz-ops-relationship-annotate').should(
+			'not.exist',
+		);
+
+		cy.get('#ul-curiousChild li')
+			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations');
 	});
 
 	it('displays all fields defined for that relationship property', () => {
@@ -102,6 +176,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations')
 			.click({ force: true });
 
 		cy.get(
@@ -115,9 +190,6 @@ describe('End-to-end - annotate rich relationship properties', () => {
 					.should('be.visible');
 				cy.wrap(parent)
 					.find('#id-anotherString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someString')
 					.should('be.visible');
 				cy.wrap(parent)
 					.find('#id-someInteger')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -131,7 +131,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.should('be.disabled');
 	});
 
-	it('sets label of the button as "Add annotations", if no annotation was done for existing relationships', () => {
+	it('sets label of the button as "Add annotations", if no annotations already exist for existing relationships', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -146,7 +146,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.find('button.relationship-annotate-button')
 			.should('have.text', 'Add annotations');
 	});
-	it('sets label of the button as "Edit annotations", if some annotations was done for existing relationships', () => {
+	it('sets label of the button as "Edit annotations", if annotations already exist for existing relationships', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -24,7 +24,7 @@ describe('End-to-end - edit relationship properties', () => {
 		visitMainTypePage();
 	});
 
-	it('does not render fields on page load', () => {
+	it('does not render annotation fields on page load for existing relationships', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -38,7 +38,7 @@ describe('End-to-end - edit relationship properties', () => {
 		);
 	});
 
-	it('renders fields when Annotate button is clicked', () => {
+	it('shows fields when the annotation button is clicked', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -54,32 +54,6 @@ describe('End-to-end - edit relationship properties', () => {
 		cy.get(
 			'#ul-curiousChild span.treecreeper-relationship-annotate',
 		).should('be.visible');
-	});
-
-	it('hides fields when Annotate button is clicked, if they are visible', () => {
-		visitEditPage();
-		pickCuriousChild();
-		save();
-
-		cy.wrap().then(() => setPropsOnCuriousChildRel(`${code}-first-child`));
-		visitMainTypePage();
-		visitEditPage();
-
-		cy.get('#ul-curiousChild li')
-			.find('button.relationship-annotate-button')
-			.click({ force: true });
-
-		cy.get(
-			'#ul-curiousChild span.treecreeper-relationship-annotate',
-		).should('be.visible');
-
-		cy.get('#ul-curiousChild li')
-			.find('button.relationship-annotate-button')
-			.click({ force: true });
-
-		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').should(
-			'not.exist',
-		);
 	});
 
 	it('displays all fields defined for that relationship property', () => {
@@ -168,6 +142,7 @@ describe('End-to-end - edit relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations')
 			.click({ force: true });
 
 		cy.get(
@@ -280,7 +255,6 @@ describe('End-to-end - edit relationship properties', () => {
 		save();
 
 		cy.wrap().then(() => setPropsOnCuriousParentRel(`${code}-parent-one`));
-		cy.wrap().then(() => setPropsOnCuriousParentRel(`${code}-parent-two`));
 		visitEditPage();
 
 		cy.get('#ul-curiousParent')
@@ -289,6 +263,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.then(child => {
 				cy.wrap(child)
 					.find('button.relationship-annotate-button')
+					.should('have.text', 'Edit annotations')
 					.click({ force: true });
 				cy.wrap(child)
 					.find('#id-someString')
@@ -299,6 +274,18 @@ describe('End-to-end - edit relationship properties', () => {
 					.should('have.value', 'parent another lorem ipsum')
 					.type(' edited parent one');
 			});
+
+		cy.get('#ul-curiousParent')
+			.children()
+			.eq(1)
+			.then(child => {
+				cy.wrap(child)
+					.find('button.relationship-annotate-button')
+					.should('have.text', 'Add annotations');
+			});
+		save();
+		cy.wrap().then(() => setPropsOnCuriousParentRel(`${code}-parent-two`));
+		visitEditPage();
 
 		cy.get('#ul-curiousParent')
 			.children()

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -64,7 +64,6 @@ class RelationshipPicker extends React.Component {
 		this.onUserMisconception = this.onUserMisconception.bind(this);
 		this.onSuggestionHighlighted = this.onSuggestionHighlighted.bind(this);
 		this.onChange = this.onChange.bind(this);
-		this.toggleAnnotation = this.toggleAnnotation.bind(this);
 	}
 
 	onRelationshipRemove(event) {
@@ -141,15 +140,6 @@ class RelationshipPicker extends React.Component {
 			});
 			return {
 				selectedRelationships,
-			};
-		});
-	}
-
-	toggleAnnotation() {
-		this.setState(prevState => {
-			const { annotate } = prevState;
-			return {
-				annotate: !annotate,
 			};
 		});
 	}
@@ -314,7 +304,6 @@ class RelationshipPicker extends React.Component {
 							index={i}
 							key={i}
 							annotate={annotate}
-							toggleAnnotation={this.toggleAnnotation}
 							onChange={this.onChange}
 							{...{ ...props, value: val }}
 						/>

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -53,7 +53,7 @@ class RelationshipPicker extends React.Component {
 			selectedRelationships,
 			hasHighlightedSelection: false,
 			isFull: !props.hasMany && !!selectedRelationships.length,
-			isExpanded: false,
+			annotate: false,
 		};
 		this.props = props;
 		this.onSearchTermChange = this.onSearchTermChange.bind(this);
@@ -64,6 +64,7 @@ class RelationshipPicker extends React.Component {
 		this.onUserMisconception = this.onUserMisconception.bind(this);
 		this.onSuggestionHighlighted = this.onSuggestionHighlighted.bind(this);
 		this.onChange = this.onChange.bind(this);
+		this.toggleAnnotation = this.toggleAnnotation.bind(this);
 	}
 
 	onRelationshipRemove(event) {
@@ -144,6 +145,15 @@ class RelationshipPicker extends React.Component {
 		});
 	}
 
+	toggleAnnotation() {
+		this.setState(prevState => {
+			const { annotate } = prevState;
+			return {
+				annotate: !annotate,
+			};
+		});
+	}
+
 	fetchSuggestions({ value }) {
 		if (!value) {
 			return;
@@ -176,13 +186,18 @@ class RelationshipPicker extends React.Component {
 		if (this.props.hasMany) {
 			this.setState(({ selectedRelationships }) => {
 				selectedRelationships = [...selectedRelationships, suggestion];
-				return { ...neutralState, selectedRelationships };
+				return {
+					...neutralState,
+					selectedRelationships,
+					annotate: true,
+				};
 			});
 		} else {
 			this.setState({
 				...neutralState,
 				selectedRelationships: [suggestion],
 				isFull: true,
+				annotate: true,
 			});
 		}
 		// this is needed to prevent the event propagating up and then
@@ -230,7 +245,7 @@ class RelationshipPicker extends React.Component {
 			isUserError,
 			isUnresolved,
 			isFull,
-			isExpanded,
+			annotate,
 		} = this.state;
 		return (
 			<div
@@ -298,7 +313,8 @@ class RelationshipPicker extends React.Component {
 							onRelationshipRemove={this.onRelationshipRemove}
 							index={i}
 							key={i}
-							isExpanded={isExpanded}
+							annotate={annotate}
+							toggleAnnotation={this.toggleAnnotation}
 							onChange={this.onChange}
 							{...{ ...props, value: val }}
 						/>

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -145,6 +145,7 @@ class RelationshipPicker extends React.Component {
 	}
 
 	fetchSuggestions({ value }) {
+		const { parentCode } = this.props;
 		if (!value) {
 			return;
 		}
@@ -156,11 +157,12 @@ class RelationshipPicker extends React.Component {
 				this.setState(({ selectedRelationships }) => ({
 					suggestions: suggestions
 						// avoid new suggestions including values that have already been selected
+						// don't suggest itself (relationship to self is not supported at the moment)
 						.filter(
 							suggestion =>
 								!selectedRelationships.find(
 									({ code }) => code === suggestion.code,
-								),
+								) && parentCode !== suggestion.code,
 						),
 				}));
 			});

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
@@ -8,6 +8,8 @@ class Relationship extends React.Component {
 		this.state = {
 			isMounted: false,
 			isEditing: this.props.annotate,
+			// so that to show annotation fields when a relationship is created
+			annotate: this.props.annotate,
 		};
 
 		this.showRichRelationshipEditor = this.showRichRelationshipEditor.bind(
@@ -24,12 +26,21 @@ class Relationship extends React.Component {
 		});
 	}
 
+	toggleAnnotation() {
+		this.setState(prevState => {
+			const { annotate } = prevState;
+			return {
+				annotate: !annotate,
+			};
+		});
+	}
+
 	showRichRelationshipEditor(event) {
 		this.setState(
 			{
 				isEditing: true,
 			},
-			() => this.props.toggleAnnotation(),
+			() => this.toggleAnnotation(),
 		);
 		event.stopPropagation();
 	}
@@ -42,10 +53,9 @@ class Relationship extends React.Component {
 			index,
 			properties,
 			propertyName,
-			annotate,
 		} = this.props;
 
-		const { isMounted, isEditing } = this.state;
+		const { isMounted, isEditing, annotate } = this.state;
 		const relationshipPropKeys = properties && Object.keys(properties);
 		const canBeAnnotated =
 			relationshipPropKeys && relationshipPropKeys.length > 0;

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
@@ -46,14 +46,17 @@ class Relationship extends React.Component {
 		} = this.props;
 
 		const { isMounted, isEditing } = this.state;
-		const canBeAnnotated = Object.keys(properties).length > 0;
-		const hasAnnotations = Object.keys(properties).filter(
-			propName => value[propName],
-		);
+		const relationshipPropKeys = properties && Object.keys(properties);
+		const canBeAnnotated =
+			relationshipPropKeys && relationshipPropKeys.length > 0;
+		const hasAnnotations =
+			relationshipPropKeys &&
+			relationshipPropKeys.filter(propName => value[propName]);
 
-		const annotateButtonLabel = hasAnnotations.length
-			? 'Edit annotations'
-			: 'Add annotations';
+		const annotateButtonLabel =
+			hasAnnotations && hasAnnotations.length
+				? 'Edit annotations'
+				: 'Add annotations';
 		return (
 			<>
 				<li

--- a/packages/tc-ui/src/primitives/relationship/lib/rich-relationship-properties.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/rich-relationship-properties.jsx
@@ -1,38 +1,54 @@
+/* global window */
 const React = require('react');
 const { getEnums } = require('@financial-times/tc-schema-sdk');
 const {
 	componentAssigner,
 } = require('../../../lib/mappers/component-assigner');
-const { getValue } = require('../../../lib/mappers/get-value.js');
+const { getValue } = require('../../../lib/mappers/get-value');
 
-const RelationshipProperties = props => {
-	const { value, type, properties, onChange } = props;
-	const propertyfields = Object.entries(properties);
+class RelationshipProperties extends React.Component {
+	constructor(props) {
+		super();
+		this.props = props;
+	}
 
-	return propertyfields
-		.filter(([, { deprecationReason }]) => !deprecationReason)
-		.map(([name, item], index) => {
-			const assignComponent = componentAssigner();
-			const { EditComponent } = assignComponent(item);
+	componentDidMount() {
+		if (window && window.Origami) {
+			// needed to init tooltip used for Annotate button
+			window.Origami['o-tooltip'].init();
+			window.Origami['o-expander'].init();
+		}
+	}
 
-			const viewModel = {
-				isNested: true,
-				parentCode: value.code,
-				propertyName: name,
-				value: getValue(item, value[name]),
-				onChange,
-				dataType: item.type,
-				parentType: type,
-				options: getEnums()[item.type]
-					? Object.keys(getEnums()[item.type])
-					: [],
-				label: name.toUpperCase(),
-				...item,
-			};
+	render() {
+		const { value, type, properties, onChange } = this.props;
+		const propertyfields = Object.entries(properties);
 
-			return viewModel.propertyName && viewModel.label ? (
-				<EditComponent key={index} {...viewModel} />
-			) : null;
-		});
-};
+		return propertyfields
+			.filter(([, { deprecationReason }]) => !deprecationReason)
+			.map(([name, item], index) => {
+				const assignComponent = componentAssigner();
+				const { EditComponent } = assignComponent(item);
+
+				const viewModel = {
+					isNested: true,
+					parentCode: value.code,
+					propertyName: name,
+					value: getValue(item, value[name]),
+					onChange,
+					dataType: item.type,
+					parentType: type,
+					options: getEnums()[item.type]
+						? Object.keys(getEnums()[item.type])
+						: [],
+					label: name.toUpperCase(),
+					...item,
+				};
+
+				return viewModel.propertyName && viewModel.label ? (
+					<EditComponent key={index} {...viewModel} />
+				) : null;
+			});
+	}
+}
 module.exports = { RelationshipProperties };

--- a/packages/tc-ui/src/primitives/relationship/main.css
+++ b/packages/tc-ui/src/primitives/relationship/main.css
@@ -115,11 +115,11 @@
 .relationship-remove-button,
 .relationship-annotate-button {
 	min-width: 60px;
-	width: 70px;
 }
 
 .relationship-annotate-button {
 	margin-left: 0.5em;
+	margin-right: 0 !important;
 }
 
 .relationship-remove-button {


### PR DESCRIPTION
## Why?
[Improvements to rich relationship UX](https://trello.com/c/arkemHJ0/287-improvements-to-rich-relationship-ux)

## What?
Made the following changes based on the feedback we got
- [x] In view mode each annotation should be on its own row
- [x] In edit mode close all existing annotations for existing relationships
- [x] In edit mode expand annotations area when adding new relationship
- [x] Once annotations area is opened, don't allow closing again (to avoid users accidentally saving data they can't see any more)
- [x] For existing relationships button should read 'add annotations' if none exist, or 'edit annotations' if some do
- [x] Show annotation button only for relationships that can be annotated
- [x] Add tests to validate the above changes

### Anything in particular you'd like to highlight to reviewers?
- the description I used for tests looks very long - what is your thought on that?

## Screenshots / Images
![Mar-03-2020 14-23-53](https://user-images.githubusercontent.com/9718606/75784808-aa127e80-5d5a-11ea-920b-7d880794d47d.gif)

