### PR TITLE
restore in-progress edits to relationships if form submission errors

### DIFF
--- a/packages/tc-ui/src/lib/get-data-transformers.js
+++ b/packages/tc-ui/src/lib/get-data-transformers.js
@@ -65,7 +65,15 @@ const getDataTransformers = (assignComponent, clientId) => {
 					formData[fieldName] &&
 					formData[fieldName] !== "Don't know"
 				) {
-					data[fieldName] = parser(formData[fieldName]);
+					if (fieldProps.isRelationship) {
+						data[fieldName] = parser(
+							formData[fieldName],
+							fieldProps.properties,
+							assignComponent,
+						);
+					} else {
+						data[fieldName] = parser(formData[fieldName]);
+					}
 				}
 			},
 		);

--- a/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
+++ b/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
@@ -14,15 +14,16 @@ const {
 
 describe('End-to-end - delete record', () => {
 	beforeEach(() => {
-		resetDb();
-		cy.visit(`/MainType/create`, {
-			onBeforeLoad(win) {
-				cy.stub(win, 'prompt').returns('SAVE INCOMPLETE RECORD');
-			},
+		cy.wrap(resetDb()).then(() => {
+			cy.visit(`/MainType/create`, {
+				onBeforeLoad(win) {
+					cy.stub(win, 'prompt').returns('SAVE INCOMPLETE RECORD');
+				},
+			});
+			cy.get('input[name=code]').type(code);
+			cy.get('input[name=someString]').type(someString);
+			save();
 		});
-		cy.get('input[name=code]').type(code);
-		cy.get('input[name=someString]').type(someString);
-		save();
 	});
 
 	it('shows a prompt message', () => {

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
@@ -19,9 +19,10 @@ const {
 
 describe('End-to-end - edit record', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+		});
 	});
 
 	it('can not edit code of record', () => {

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -5,7 +5,7 @@ const { Concept, SectionHeader } = require('../../lib/components/structure');
 const { getValue } = require('../../lib/mappers/get-value');
 const { SaveButton, CancelButton } = require('../../lib/components/buttons');
 
-const PropertyInputs = ({ fields, data, type, assignComponent }) => {
+const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 	const propertyfields = Object.entries(fields);
 
 	const fieldsToLock = data._lockedFields
@@ -26,10 +26,11 @@ const PropertyInputs = ({ fields, data, type, assignComponent }) => {
 
 			const { EditComponent } = assignComponent(propDef);
 			const itemValue = propDef.isRelationship
-				? data[`${propertyName}_rel`]
+				? data[`${propertyName}_rel`] || data[propertyName]
 				: data[propertyName];
 
 			const viewModel = {
+				hasError,
 				parentCode: data.code,
 				propertyName,
 				value: getValue(propDef, itemValue),
@@ -112,6 +113,7 @@ const EditForm = props => {
 									<SectionHeader title={heading} />
 								</div>
 								<PropertyInputs
+									hasError={!!error}
 									fields={properties}
 									data={data}
 									type={type}

--- a/packages/tc-ui/src/primitives/boolean/__tests__/e2e-record-boolean.cyp.js
+++ b/packages/tc-ui/src/primitives/boolean/__tests__/e2e-record-boolean.cyp.js
@@ -8,10 +8,11 @@ const {
 
 describe('End-to-end - record Boolean type', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		cy.get('#radio-someBoolean-Yes').check({ force: true });
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			cy.get('#radio-someBoolean-Yes').check({ force: true });
+			save();
+		});
 	});
 
 	it('can record a value', () => {

--- a/packages/tc-ui/src/primitives/boolean/server.jsx
+++ b/packages/tc-ui/src/primitives/boolean/server.jsx
@@ -102,6 +102,10 @@ module.exports = {
 			{...props}
 		/>
 	),
-	parser: value => (value === undefined ? undefined : value === 'true'),
+	parser: value => {
+		// String(value) - on submission error the value we get is
+		// is boolean because that is what neo4j returns (true !== 'true')
+		return value === undefined ? undefined : String(value) === 'true';
+	},
 	hasValue: value => typeof value === 'boolean',
 };

--- a/packages/tc-ui/src/primitives/enum/__tests__/e2e-record-enum.cyp.js
+++ b/packages/tc-ui/src/primitives/enum/__tests__/e2e-record-enum.cyp.js
@@ -8,10 +8,11 @@ const {
 
 describe('End-to-end - record Enum type', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		cy.get('select[name=someEnum]').select('First');
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			cy.get('select[name=someEnum]').select('First');
+			save();
+		});
 	});
 
 	it('can record a selection', () => {

--- a/packages/tc-ui/src/primitives/large-text/__tests__/e2e-record-large-text.cyp.js
+++ b/packages/tc-ui/src/primitives/large-text/__tests__/e2e-record-large-text.cyp.js
@@ -11,13 +11,14 @@ const {
 
 describe('End-to-end - record LargeText type', () => {
 	it('can record large text', () => {
-		resetDb();
-		populateMinimumViableFields(code);
-		cy.get('textarea[name=someDocument]').type(someDocument);
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			cy.get('textarea[name=someDocument]').type(someDocument);
+			save();
 
-		cy.get('#code').should('have.text', code);
-		cy.get('#someString').should('have.text', someString);
-		cy.get('#someDocument').should('have.text', someDocument);
+			cy.get('#code').should('have.text', code);
+			cy.get('#someString').should('have.text', someString);
+			cy.get('#someDocument').should('have.text', someDocument);
+		});
 	});
 });

--- a/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
+++ b/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
@@ -8,11 +8,12 @@ const {
 
 describe('End-to-end - record multiple choice value', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
 
-		visitEditPage();
+			visitEditPage();
+		});
 	});
 
 	it('can record a single choice', () => {

--- a/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
+++ b/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
@@ -11,8 +11,9 @@ const {
 
 describe('End-to-end - record Number type', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+		});
 	});
 
 	it('can record an integer', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -22,14 +22,15 @@ const {
 
 describe('End-to-end - annotate rich relationship properties', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
-		populateParentTypeFields(`${code}-parent-one`);
-		save();
-		populateParentTypeFields(`${code}-parent-two`);
-		save();
-		visitMainTypePage();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+			populateParentTypeFields(`${code}-parent-one`);
+			save();
+			populateParentTypeFields(`${code}-parent-two`);
+			save();
+			visitMainTypePage();
+		});
 	});
 
 	it('does not show annotation fields on page load', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-create-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-create-relationships.cyp.js
@@ -14,15 +14,16 @@ const {
 
 describe('End-to-end - relationship creation', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
-		populateParentTypeFields(`${code}-parent`);
-		save();
-		populateChildTypeFields(`${code}-second-child`);
-		save();
-		visitMainTypePage();
-		visitEditPage();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+			populateParentTypeFields(`${code}-parent`);
+			save();
+			populateChildTypeFields(`${code}-second-child`);
+			save();
+			visitMainTypePage();
+			visitEditPage();
+		});
 	});
 
 	describe('one-to-one relationship', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
@@ -12,13 +12,14 @@ const {
 
 describe('End-to-end - relationship deletion', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
-		populateChildTypeFields(`${code}-first-child`);
-		save();
-		populateChildTypeFields(`${code}-second-child`);
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+			populateChildTypeFields(`${code}-first-child`);
+			save();
+			populateChildTypeFields(`${code}-second-child`);
+			save();
+		});
 	});
 
 	it('can remove 1-to-1 relationship', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
@@ -15,16 +15,17 @@ const {
 
 describe('End-to-end - display relationship properties', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
-		populateParentTypeFields(`${code}-parent-one`);
-		save();
-		populateParentTypeFields(`${code}-parent-two`);
-		save();
-		populateChildTypeFields(`${code}-second-child`);
-		save();
-		visitMainTypePage();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+			populateParentTypeFields(`${code}-parent-one`);
+			save();
+			populateParentTypeFields(`${code}-parent-two`);
+			save();
+			populateChildTypeFields(`${code}-second-child`);
+			save();
+			visitMainTypePage();
+		});
 	});
 
 	it('can display/hide relationship properties', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -14,14 +14,15 @@ const {
 
 describe('End-to-end - edit relationship properties', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
-		save();
-		populateParentTypeFields(`${code}-parent-one`);
-		save();
-		populateParentTypeFields(`${code}-parent-two`);
-		save();
-		visitMainTypePage();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			save();
+			populateParentTypeFields(`${code}-parent-one`);
+			save();
+			populateParentTypeFields(`${code}-parent-two`);
+			save();
+			visitMainTypePage();
+		});
 	});
 
 	it('does not render annotation fields on page load for existing relationships', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -352,4 +352,132 @@ describe('End-to-end - edit relationship properties', () => {
 					);
 			});
 	});
+
+	it('restores in-progress edits to the relationship annotations if the form is submitted but errors', () => {
+		visitEditPage();
+		pickCuriousChild();
+		save();
+
+		cy.wrap().then(() => setPropsOnCuriousChildRel(`${code}-first-child`));
+		visitEditPage();
+
+		cy.get('#ul-curiousChild li')
+			.find('button.relationship-annotate-button')
+			.should('have.text', 'Edit annotations')
+			.click({ force: true });
+
+		cy.get(
+			'#ul-curiousChild span.treecreeper-relationship-annotate',
+		).should('be.visible');
+
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
+			parent => {
+				cy.wrap(parent)
+					.find('#id-someString')
+					.should('have.value', 'lorem ipsum');
+				cy.wrap(parent)
+					.find('#id-anotherString')
+					.should('have.value', 'another lorem ipsum');
+				cy.wrap(parent)
+					.find('#id-someInteger')
+					.should('have.value', '2020');
+				cy.wrap(parent)
+					.find('#id-someEnum')
+					.children()
+					.eq(1)
+					.should('have.value', 'First')
+					.should('be.selected');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-First')
+					.should('be.checked');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-Third')
+					.should('be.checked');
+				cy.wrap(parent)
+					.find('#radio-someBoolean-Yes')
+					.should('be.checked');
+				cy.wrap(parent)
+					.find('#id-someFloat')
+					.should('have.value', '12.53');
+
+				// edit
+				cy.wrap(parent)
+					.find('#id-someString')
+					.type(' edited');
+				cy.wrap(parent)
+					.find('#id-anotherString')
+					.type(' edited');
+				cy.wrap(parent)
+					.find('#id-someInteger')
+					.clear()
+					// this will make the form submission error as the value is not a finite integer
+					.type(20.23);
+				cy.wrap(parent)
+					.find('#id-someEnum')
+					.select('Third');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-First')
+					.uncheck({ force: true });
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-Third')
+					.uncheck({
+						force: true,
+					});
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-Second')
+					.check({ force: true });
+			},
+		);
+		save();
+
+		cy.url().should('contain', `/MainType/${code}/edit`);
+		// assert submission has thrown an error
+		cy.get('.o-message__content-main').should(
+			'contain',
+			'Oops. Could not update MainType record for e2e-demo',
+		);
+		cy.get('.o-message__content-additional').should(
+			'contain',
+			`Invalid value \`20.23\` for property \`someInteger\` on type \`CuriousChild\`: Must be a finite integer`,
+		);
+
+		// assert in-progress edits are restored
+		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
+			parent => {
+				// assert it shows in-progress changes not original data
+				cy.wrap(parent)
+					.find('#id-someString')
+					.should('have.value', 'lorem ipsum edited');
+				cy.wrap(parent)
+					.find('#id-anotherString')
+					.should('have.value', 'another lorem ipsum edited');
+				cy.wrap(parent)
+					.find('#id-someInteger')
+					// the value that caused the error not 2020
+					.should('have.value', '20.23');
+				cy.wrap(parent)
+					.find('#id-someEnum')
+					.children()
+					.eq(3)
+					.should('have.value', 'Third')
+					.should('be.selected');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-First')
+					.should('not.be.checked');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-Second')
+					.should('be.checked');
+				cy.wrap(parent)
+					.find('#checkbox-someMultipleChoice-Third')
+					.should('not.be.checked');
+				// original data form neo4j
+				cy.wrap(parent)
+					.find('#radio-someBoolean-Yes')
+					.should('be.checked');
+				cy.wrap(parent)
+					.find('#id-someFloat')
+					.should('have.value', '12.53');
+			},
+		);
+	});
 });

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -157,7 +157,7 @@ class RelationshipPicker extends React.Component {
 				this.setState(({ selectedRelationships }) => ({
 					suggestions: suggestions
 						// avoid new suggestions including values that have already been selected
-						// don't suggest itself (relationship to self is not supported at the moment)
+						// don't suggest self (relationship to self is not supported at the moment)
 						.filter(
 							suggestion =>
 								!selectedRelationships.find(
@@ -228,7 +228,7 @@ class RelationshipPicker extends React.Component {
 
 	render() {
 		const { props } = this;
-		const { propertyName } = props;
+		const { propertyName, hasError } = props;
 		const disabled = !!this.props.lockedBy;
 		const {
 			searchTerm,
@@ -301,6 +301,7 @@ class RelationshipPicker extends React.Component {
 				>
 					{selectedRelationships.map((val, i) => (
 						<Relationship
+							hasError={hasError}
 							disabled={disabled}
 							onRelationshipRemove={this.onRelationshipRemove}
 							index={i}

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
@@ -53,6 +53,7 @@ class Relationship extends React.Component {
 			index,
 			properties,
 			propertyName,
+			hasError,
 		} = this.props;
 
 		const { isMounted, isEditing, annotate } = this.state;
@@ -99,7 +100,9 @@ class Relationship extends React.Component {
 									<button
 										type="button"
 										disabled={
-											disabled || isEditing
+											disabled ||
+											isEditing ||
+											(hasError && hasAnnotations.length)
 												? 'disabled'
 												: null
 										}
@@ -129,7 +132,8 @@ class Relationship extends React.Component {
 							) : null}
 						</span>
 					</span>
-					{isMounted && annotate && canBeAnnotated ? (
+					{(isMounted && annotate && canBeAnnotated) ||
+					(hasError && hasAnnotations.length) ? (
 						<span
 							className="treecreeper-relationship-annotate"
 							key={index}

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -12,8 +12,9 @@ const {
 
 describe('End-to-end - record Temporal type', () => {
 	beforeEach(() => {
-		resetDb();
-		populateMinimumViableFields(code);
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+		});
 	});
 
 	it('can record date', () => {

--- a/packages/tc-ui/src/primitives/text/__tests__/e2e-record-text.cyp.js
+++ b/packages/tc-ui/src/primitives/text/__tests__/e2e-record-text.cyp.js
@@ -11,13 +11,14 @@ const {
 
 describe('End-to-end - record Text type', () => {
 	it('can record a text', () => {
-		resetDb();
-		populateMinimumViableFields(code);
-		cy.get('input[name=anotherString]').type(anotherString);
-		save();
+		cy.wrap(resetDb()).then(() => {
+			populateMinimumViableFields(code);
+			cy.get('input[name=anotherString]').type(anotherString);
+			save();
 
-		cy.get('#code').should('have.text', code);
-		cy.get('#someString').should('have.text', someString);
-		cy.get('#anotherString').should('have.text', anotherString);
+			cy.get('#code').should('have.text', code);
+			cy.get('#someString').should('have.text', someString);
+			cy.get('#anotherString').should('have.text', anotherString);
+		});
 	});
 });


### PR DESCRIPTION
## Why?
We need to restore in-progress edit to relationships if form submission errors

## What?
- made `formDataToGraphQL` of get-data-transformers to call the parser with rel-props and component assigner function in case of relationships
- make relationship-picker component aware when a submission errors on the api
- added tests to validate the changes

### Anything in particular you'd like to highlight to reviewers?
- To be sure that all cypress setups/tests are run after the database in a new state, I wrapped every call to `resetDb` in cy.wrap ... following the discussion [here](https://github.com/cypress-io/cypress/issues/3172)

## Screenshots / Images
![Mar-04-2020 13-21-36](https://user-images.githubusercontent.com/9718606/75883817-89f6c400-5e1b-11ea-80f4-4226be41a874.gif)
