### PR TITLE
fix bug detecting all error states for enum parser

### DIFF
--- a/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
+++ b/packages/tc-markdown-parser/lib/tree-mutators/coerce-treecreeper-properties-to-type.js
@@ -78,7 +78,13 @@ const coerceEnumPropertyValue = (
 	{ propertyType: enumName, hasMany, enums },
 ) => {
 	let [subdocument] = node.children;
-
+	const validValues = Object.values(enums[enumName]);
+	if (!subdocument.children.length) {
+		return convertNodeToProblem({
+			node,
+			message: `Must provide a value. Valid values: ${validValues.toString()}`,
+		});
+	}
 	if (hasMany) {
 		if (subdocument.children[0].type !== 'list') {
 			return convertNodeToProblem({
@@ -93,8 +99,6 @@ const coerceEnumPropertyValue = (
 			message: 'Must provide a single enum, not a nested list',
 		});
 	}
-
-	const validValues = Object.values(enums[enumName]);
 
 	const values = subdocument.children.map(child => {
 		const flattenedContent = normalizePropertyKey(
@@ -210,7 +214,6 @@ module.exports = function coerceTreecreeperPropertiesToType({
 				propertyType,
 			});
 		}
-
 		// If it's an enum, make sure it's a valid value for that enum
 		if (propertyType in enums) {
 			coerceEnumPropertyValue(node, {


### PR DESCRIPTION
## Why?

In runbook.md, tc-markdown-parser@0.4.0 was failing a test. The test tested if, when a parse error happened, the error message contained the correct line numbers. However in order to generate the problem node (which is the mechanism to respond with multiple parse errors) the error must be manually caught and converted. In the refactor when supporting multiple choice enums I'd inadvertently added a potential error state I wasn't catching.

## What?
Covers the case when the heading of a field which is supposed to contain an enum (or multi enum) has no content beneath it - checks for the length of child nodes and converts to a problem immediately if there are no children

Note - there are _no_ tests for error states in this package. Given that user experience depends on us covering them carefully I will add a ticket to create some