### PR TITLE
change annotation label to details and add icons

### DIFF
--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -58,7 +58,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations')
+			.should('have.text', 'Edit details')
 			.click({ force: true });
 
 		cy.get(
@@ -120,7 +120,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations')
+			.should('have.text', 'Edit details')
 			.click({ force: true });
 
 		cy.get(
@@ -132,7 +132,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 			.should('be.disabled');
 	});
 
-	it('sets label of the button as "Add annotations", if no annotations already exist for existing relationships', () => {
+	it('sets label of the button as "Add details", if no annotations already exist for existing relationships', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -145,9 +145,9 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Add annotations');
+			.should('have.text', 'Add details');
 	});
-	it('sets label of the button as "Edit annotations", if annotations already exist for existing relationships', () => {
+	it('sets label of the button as "Edit details", if annotations already exist for existing relationships', () => {
 		visitEditPage();
 		pickCuriousChild();
 		save();
@@ -162,7 +162,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations');
+			.should('have.text', 'Edit details');
 	});
 
 	it('displays all fields defined for that relationship property', () => {
@@ -177,7 +177,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations')
+			.should('have.text', 'Edit details')
 			.click({ force: true });
 
 		cy.get(

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
@@ -48,7 +48,7 @@ describe('End-to-end - display relationship properties', () => {
 			.should('not.be.visible');
 
 		cy.get('[aria-controls="o-expander__toggle--1"]')
-			.should('have.text', 'more info')
+			.should('have.text', 'view details')
 			.click();
 
 		cy.get('#curiousChild')
@@ -75,7 +75,7 @@ describe('End-to-end - display relationship properties', () => {
 			});
 
 		cy.get('[aria-controls="o-expander__toggle--1"]')
-			.should('have.text', 'less')
+			.should('have.text', 'hide details')
 			.click();
 
 		cy.get('#curiousChild')

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -143,7 +143,7 @@ describe('End-to-end - edit relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations')
+			.should('have.text', 'Edit details')
 			.click({ force: true });
 
 		cy.get(
@@ -264,7 +264,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.then(child => {
 				cy.wrap(child)
 					.find('button.relationship-annotate-button')
-					.should('have.text', 'Edit annotations')
+					.should('have.text', 'Edit details')
 					.click({ force: true });
 				cy.wrap(child)
 					.find('#id-someString')
@@ -282,7 +282,7 @@ describe('End-to-end - edit relationship properties', () => {
 			.then(child => {
 				cy.wrap(child)
 					.find('button.relationship-annotate-button')
-					.should('have.text', 'Add annotations');
+					.should('have.text', 'Add details');
 			});
 		save();
 		cy.wrap().then(() => setPropsOnCuriousParentRel(`${code}-parent-two`));
@@ -364,7 +364,7 @@ describe('End-to-end - edit relationship properties', () => {
 
 		cy.get('#ul-curiousChild li')
 			.find('button.relationship-annotate-button')
-			.should('have.text', 'Edit annotations')
+			.should('have.text', 'Edit details')
 			.click({ force: true });
 
 		cy.get(

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship.jsx
@@ -66,8 +66,12 @@ class Relationship extends React.Component {
 
 		const annotateButtonLabel =
 			hasAnnotations && hasAnnotations.length
-				? 'Edit annotations'
-				: 'Add annotations';
+				? 'Edit details'
+				: 'Add details';
+		const annotateButtonIcon =
+			hasAnnotations && hasAnnotations.length
+				? ` o-icons-icon--edit`
+				: ` o-icons-icon--plus`;
 		return (
 			<>
 				<li
@@ -115,7 +119,10 @@ class Relationship extends React.Component {
 										data-index={`annotate-${index}`}
 										id={`id-${propertyName}-${index}`}
 									>
-										{annotateButtonLabel}
+										<span>{annotateButtonLabel}</span>
+										<span
+											className={`relationship-annotate-icon o-icons-icon ${annotateButtonIcon}`}
+										/>
 									</button>
 									<div
 										data-o-component="o-tooltip"

--- a/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
@@ -38,7 +38,7 @@ const OneRelationship = props => {
 			>
 				{' '}
 				<button className="o-expander__toggle o--if-js" type="button">
-					View details
+					view details
 				</button>
 				<div className="o-expander__content">
 					<dl className="treecreeper-relationship-props-list">

--- a/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
@@ -33,12 +33,12 @@ const OneRelationship = props => {
 				data-o-component="o-expander"
 				className="o-expander"
 				data-o-expander-shrink-to="hidden"
-				data-o-expander-collapsed-toggle-text="more info"
-				data-o-expander-expanded-toggle-text="less"
+				data-o-expander-collapsed-toggle-text="view details"
+				data-o-expander-expanded-toggle-text="hide details"
 			>
 				{' '}
 				<button className="o-expander__toggle o--if-js" type="button">
-					more info
+					View details
 				</button>
 				<div className="o-expander__content">
 					<dl className="treecreeper-relationship-props-list">

--- a/packages/tc-ui/src/primitives/relationship/main.css
+++ b/packages/tc-ui/src/primitives/relationship/main.css
@@ -118,10 +118,32 @@
 }
 
 .relationship-annotate-button {
-	margin-left: 0.5em;
 	margin-right: 0 !important;
+	margin-left: 0.5em;
+	padding-top: 0;
+	padding-right: 0;
+	padding-bottom: 0;
 }
 
 .relationship-remove-button {
 	margin: auto 0 !important;
+	padding-top: 0.5em;
+	padding-bottom: 0.5em;
+}
+
+.relationship-annotate-button span:first-of-type {
+	vertical-align: middle;
+}
+
+.relationship-annotate-icon {
+	width: 1em;
+	height: 1em;
+	font-size: 2em;
+	vertical-align: middle;
+	color: var(--o-colors-black-10);
+}
+
+.relationship-annotate-button .o-icons-icon--edit {
+	height: 0.9em !important;
+	padding-top: 0.1em;
 }


### PR DESCRIPTION
## Why?

We conducted a user testing for annotating relationships and this PR addresses some of the feedback we got

## What?

- replaced `Add|Edit annotations` with `Add|Edit details` - Edit page
- replaced `more info` with `view details` and `less` with `hide details` - View page
- added plus/edit icons on the annotation button

### Anything in particular you'd like to highlight to reviewers?

None

## Screenshots / Images

### Edit page
![Screenshot 2020-03-10 at 15 59 10](https://user-images.githubusercontent.com/9718606/76336082-620cd200-62ed-11ea-8100-c301f356b77c.png)

### View page
![Screenshot 2020-03-10 at 16 33 21](https://user-images.githubusercontent.com/9718606/76336244-9ed8c900-62ed-11ea-97ff-998b25a6c924.png)
