### PR TITLE
fix bug when value of relationship is null

### DIFF
--- a/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/view-relationship.jsx
@@ -20,6 +20,11 @@ const OneRelationship = props => {
 	} = props;
 	let RelationshipProperties = null;
 	// value[propertyName] !== null since neo4j returns null if there is no value
+
+	if (!value) {
+		return null;
+	}
+
 	const validValues = Object.keys(value)
 		.filter(
 			propertyName =>


### PR DESCRIPTION
## Why?

- in Biz Ops admin some of the Report pages were broken (UNOWNED SYSTEMS, UNSUPPORTED SYSTEMS, UNDEFINED SYSTEMS)

## What?
- added check for relationship values

## Screenshots / Images

![screencapture-local-in-ft-3000-list-Systems-2020-03-13-16_28_01](https://user-images.githubusercontent.com/9718606/76640357-b1e6d580-6547-11ea-8387-47cb93930b79.png)


