### PR TITLE
fix removing child of index greater than 0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           root: *workspace_root
           paths:
             - .
-  build:
+  cypress-build:
     <<: *default_container_config
 
     steps:
@@ -156,7 +156,7 @@ workflows:
       - install:
           context: rel-eng-creds
           filters: *only_version_tags
-      - build:
+      - cypress-build:
           requires:
             - install
       - test:
@@ -170,7 +170,7 @@ workflows:
           filters: *only_version_tags
       - end-to-end-test:
           requires:
-            - build
+            - cypress-build
           filters: *only_version_tags
       # Scan package.json for vulnerable dependencies while developing
       - ft-snyk-orb/scan-js-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,7 @@ workflows:
       - cypress-build:
           requires:
             - install
+          filters: *only_version_tags
       - test:
           requires:
             - install

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
@@ -45,7 +45,7 @@ describe('End-to-end - relationship deletion', () => {
 		cy.get('#favouriteChild').should('not.exist');
 	});
 
-	it('can remove a relationship from 1-to-many relationship', () => {
+	it('can remove first relationship from 1-to-many relationship', () => {
 		visitMainTypePage();
 		visitEditPage();
 
@@ -81,6 +81,44 @@ describe('End-to-end - relationship deletion', () => {
 			.should('have.text', `${code}-second-child`)
 			.find('a')
 			.should('have.attr', 'href', `/ChildType/${code}-second-child`);
+	});
+
+	it('can remove nth relationship from 1-to-many relationship', () => {
+		visitMainTypePage();
+		visitEditPage();
+
+		// pick second child
+		pickChild();
+
+		save();
+		cy.url().should('contain', `/MainType/${code}`);
+
+		cy.get('#children>li')
+			.eq(0)
+			.should('have.text', `${code}-first-child`)
+			.find('a')
+			.should('have.attr', 'href', `/ChildType/${code}-first-child`);
+
+		cy.get('#children>li')
+			.eq(1)
+			.should('have.text', `${code}-second-child`)
+			.find('a')
+			.should('have.attr', 'href', `/ChildType/${code}-second-child`);
+
+		visitEditPage();
+		cy.get('#ul-children>li')
+			.eq(1)
+			.find('button.relationship-remove-button')
+			.should('have.text', 'Remove')
+			.click();
+		save();
+
+		cy.url().should('contain', `/MainType/${code}`);
+		cy.get('#children>li')
+			.eq(0)
+			.should('have.text', `${code}-first-child`)
+			.find('a')
+			.should('have.attr', 'href', `/ChildType/${code}-first-child`);
 	});
 
 	it('can remove all relationships from 1-to-many relationship', () => {

--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -71,7 +71,7 @@ class RelationshipPicker extends React.Component {
 		// React witchcraft, event has been replaced by a null one by the time we get to
 		// the setState callback (I presume React implements some kind of instance reuse
 		// optimisation, which doesn't hang around for async stuff to execute)
-		const buttonIndex = event.target.dataset.index;
+		const buttonIndex = Number(event.target.dataset.index.split('-')[1]);
 		this.setState(({ selectedRelationships }) => {
 			selectedRelationships = [...selectedRelationships];
 			selectedRelationships.splice(buttonIndex, 1);


### PR DESCRIPTION
## Why?

@conor-mullen reported that any remove button on relationships was always removing the first one https://financialtimes.slack.com/archives/C07B3043U/p1584963133098000

## What?

Since adding additional buttons to the relationship interface the remove buttons' data attributes are now prefixed with `remove-`, which means some string manipulation needs to happen before using as an index value.

Also added a test to catch this case