### PR TITLE
Interesting related codes

### DIFF
--- a/example-schema/relationships/OddThing.yaml
+++ b/example-schema/relationships/OddThing.yaml
@@ -1,0 +1,13 @@
+name: OddThing
+from:
+  type: MainType
+  hasMany: false
+to:
+  type: OddCodeType
+  hasMany: true
+relationship: HAS_ODD_CODED_THING
+properties:
+  oddString:
+    label: Label for odd string
+    description: Description for odd string.
+    type: Word

--- a/example-schema/type-hierarchy.yaml
+++ b/example-schema/type-hierarchy.yaml
@@ -6,3 +6,4 @@ test:
     - ParentType
     - ChildType
     - RestrictedType
+    - OddCodeType

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -140,3 +140,7 @@ properties:
     description: Curious older sibling description.
     label: Curious older sibling label
     direction: incoming
+  oddThings:
+    type: OddThing
+    description: Odd thing relationship description
+    label: Odd thing relationship label

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -142,5 +142,5 @@ properties:
     direction: incoming
   oddThings:
     type: OddThing
-    description: Odd thing relationship description
+    description: Odd thing relationship description.
     label: Odd thing relationship label

--- a/example-schema/types/OddCodeType.yaml
+++ b/example-schema/types/OddCodeType.yaml
@@ -10,5 +10,5 @@ properties:
     pattern: PERMISSIVE
   mainThing:
     type: OddThing
-    description: Main thing relationship description
+    description: Main thing relationship description.
     label: Main thing relationship label

--- a/example-schema/types/OddCodeType.yaml
+++ b/example-schema/types/OddCodeType.yaml
@@ -1,0 +1,14 @@
+name: OddCodeType
+description: OddCodeType description.
+properties:
+  code:
+    type: Code
+    unique: true
+    canIdentify: true
+    description: Code description.
+    label: Code label
+    pattern: PERMISSIVE
+  mainThing:
+    type: OddThing
+    description: Main thing relationship description
+    label: Main thing relationship label

--- a/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
@@ -532,9 +532,7 @@ describe('rest PATCH relationship create', () => {
 	});
 
 	describe('upsert', () => {
-		['merge',
-		'replace'
-		].forEach(action => {
+		['merge', 'replace'].forEach(action => {
 			const handler = (body, query = {}) =>
 				patchHandler()(
 					getInput(body, { relationshipAction: action, ...query }),
@@ -1149,18 +1147,23 @@ describe('rest PATCH relationship create', () => {
 		});
 
 		it('create node related to nodes with strange codes', async () => {
-			const oddCode = `${namespace}:thing/odd`
+			const oddCode = `${namespace}:thing/odd`;
 			await createMainNode();
 			const { status, body } = await basicHandler(
 				{
-					oddThings: {code: oddCode, oddString: 'blah'},
+					oddThings: { code: oddCode, oddString: 'blah' },
 				},
 				queries,
 			);
 
 			expect(status).toBe(200);
 			expect(body).toMatchObject({
-				oddThings: [oddCode],
+				oddThings: [
+					{
+						code: oddCode,
+						oddString: 'blah',
+					},
+				],
 			});
 
 			await neo4jTest('MainType', mainCode)
@@ -1169,7 +1172,7 @@ describe('rest PATCH relationship create', () => {
 					{
 						type: 'HAS_ODD_CODED_THING',
 						direction: 'outgoing',
-						props: {oddString: 'blah', ...meta.create},
+						props: { oddString: 'blah', ...meta.create },
 					},
 					{
 						type: 'OddCodeType',

--- a/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
@@ -532,7 +532,9 @@ describe('rest PATCH relationship create', () => {
 	});
 
 	describe('upsert', () => {
-		['merge', 'replace'].forEach(action => {
+		['merge',
+		'replace'
+		].forEach(action => {
 			const handler = (body, query = {}) =>
 				patchHandler()(
 					getInput(body, { relationshipAction: action, ...query }),
@@ -1144,6 +1146,39 @@ describe('rest PATCH relationship create', () => {
 			await neo4jTest('MainType', mainCode)
 				.match(meta.default)
 				.noRels();
+		});
+
+		it('create node related to nodes with strange codes', async () => {
+			const oddCode = `${namespace}:thing/odd`
+			await createMainNode();
+			const { status, body } = await basicHandler(
+				{
+					oddThings: {code: oddCode, oddString: 'blah'},
+				},
+				queries,
+			);
+
+			expect(status).toBe(200);
+			expect(body).toMatchObject({
+				oddThings: [oddCode],
+			});
+
+			await neo4jTest('MainType', mainCode)
+				.hasRels(1)
+				.hasRel(
+					{
+						type: 'HAS_ODD_CODED_THING',
+						direction: 'outgoing',
+						props: {oddString: 'blah', ...meta.create},
+					},
+					{
+						type: 'OddCodeType',
+						props: {
+							code: oddCode,
+							...meta.create,
+						},
+					},
+				);
 		});
 	});
 });


### PR DESCRIPTION
## Why?

We'd never tried writing rich relationship props onto relationships to things with codes using symbols before. It didn't work. https://trello.com/c/DrJnmS07/313-cannot-write-rich-relationships-when-code-contains-special-characters

![image](https://user-images.githubusercontent.com/447559/77346144-a8baed00-6d2d-11ea-9f15-002751d0d499.png)


## What?

- Defines a new type that allows any string as a code in order to facilitate testing
- Takes a more aggressive approach to sanitising codes - only allows letters, digits and underscore
- Uses the index in the variable name in order to ensure uniqueness