### PR TITLE
Avoid repetitive case statements in cypher

### DIFF
--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -80,6 +80,7 @@ module.exports = {
 		TIMEOUT = timeout;
 	},
 	executeQuery: (query, parameters) =>
+		console.log(query, parameters) ||
 		driver.session().run(query, parameters),
 	executeQueryWithSharedSession: (session = driver.session()) => {
 		const executeQuery = async (...args) => {

--- a/packages/tc-api-db-manager/db-connection.js
+++ b/packages/tc-api-db-manager/db-connection.js
@@ -80,7 +80,6 @@ module.exports = {
 		TIMEOUT = timeout;
 	},
 	executeQuery: (query, parameters) =>
-		console.log(query, parameters) ||
 		driver.session().run(query, parameters),
 	executeQueryWithSharedSession: (session = driver.session()) => {
 		const executeQuery = async (...args) => {

--- a/packages/tc-api-rest-handlers/lib/metadata-helpers.js
+++ b/packages/tc-api-rest-handlers/lib/metadata-helpers.js
@@ -19,23 +19,6 @@ const metaPropertiesForCreate = recordName => stripIndents`
 `;
 // ${recordName}._lockedFields = $lockedFields,
 
-const createRelMetaQueryForUpdate = code => {
-	const metaForUpdateSets = [
-		['_updatedByRequest', '$requestId'],
-		['_updatedByClient', '$clientId'],
-		['_updatedByUser', '$clientUserId'],
-		['_updatedTimestamp', 'datetime($timestamp)'],
-	];
-
-	return metaForUpdateSets
-		.map(
-			([key, value]) => stripIndents`SET (CASE
-			WHEN related.code = '${code}'
-			THEN relationship END).${key} = ${value}`,
-		)
-		.join('\n');
-};
-
 const prepareMetadataForNeo4jQuery = (metadata = {}) => ({
 	timestamp: new Date().toISOString(),
 	requestId: metadata.requestId || null,
@@ -47,5 +30,4 @@ module.exports = {
 	prepareMetadataForNeo4jQuery,
 	metaPropertiesForUpdate,
 	metaPropertiesForCreate,
-	createRelMetaQueryForUpdate,
 };

--- a/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
@@ -41,7 +41,7 @@ const getBaseQuery = (type, method, willUpdateMeta) => {
 			return stripIndents`
 				CREATE (node:${type} $properties)
 				SET ${metaPropertiesForCreate('node')}
-				WITH node`;
+				WITH DISTINCT node`;
 		case 'MERGE':
 			return stripIndents`
 				MERGE (node:${type} { code: $code })

--- a/packages/tc-api-rest-handlers/lib/relationships/write.js
+++ b/packages/tc-api-rest-handlers/lib/relationships/write.js
@@ -88,9 +88,9 @@ const prepareToWriteRelationships = (
 
 		relationshipQueries.push(
 			stripIndents`
-			WITH node
+			WITH DISTINCT node
 			${locateRelatedNodes(relationshipSchema, key, upsert)}
-			WITH node, related, relDefs
+			WITH DISTINCT node, related, relDefs
 			MERGE ${relationshipFragmentWithEndNodes('node', relationshipSchema, 'related')}
 				ON CREATE SET ${metaPropertiesForCreate(
 					'relationship',
@@ -116,7 +116,7 @@ const prepareToWriteRelationships = (
 			) {
 				relationshipQueries.push(
 					stripIndents`
-				WITH node, related
+				WITH DISTINCT node, related
 				OPTIONAL MATCH ${relationshipFragmentWithEndNodes(
 					'otherNode',
 					relationshipSchema,
@@ -148,7 +148,7 @@ const prepareRelationshipDeletion = (nodeType, removedRelationships) => {
 			parameters[key] = codes;
 			// Must use OPTIONAL MATCH because 'cypher'
 			return stripIndents`
-				WITH node
+				WITH DISTINCT node
 					OPTIONAL MATCH (node)${relationshipFragment(
 						def.relationship,
 						def.direction,


### PR DESCRIPTION
## Why?
Ingesting information connecting repositories to teams involved generating queries so slow and complex that when e.g. ingesting a team connected to 100's of repositories, the DB fell over 
![image](https://user-images.githubusercontent.com/447559/77366839-d06f7c80-6d50-11ea-8375-3cf93bb1cc32.png)

I'm guessing the problem was the great number of `CASE` statements, a consequence of a couple of things
1. Not being able to tie a relationship effectively to the node it's related to, so when trying to target a relationship 'by code' it means filtering the entire result set each time rather than just iterating through each row once
2. Not being able to write an entire set of properties to an individual node retrieved from a larger result set - each property must be written individually, which means a CASE statement for each property. This applies to both metadata and custom properties

## What?
Well, it turns out, as is so often the case with cypher, there _is_ a better way to do it. We initially started off with arrays of codes (before all the rich relationships work). When implementing properties on relationships we didn't explore bundling the relationships in with the codes in an array of objects; I don't think any of us knew it was possible.

Well, it is, and doing that leads to far simpler source code for us, a far simpler generated cypher query and therefore, one would hope, more efficient execution