### PR TITLE
avoid writing code onto relationships

### DIFF
--- a/packages/tc-api-rest-handlers/lib/relationships/write.js
+++ b/packages/tc-api-rest-handlers/lib/relationships/write.js
@@ -50,7 +50,8 @@ const prepareToWriteRelationships = (
 
 		relProps.forEach(relProp => {
 			const props = { ...relProp };
-			delete relDefs.push({
+			delete props.code;
+			relDefs.push({
 				code: relProp.code,
 				props,
 			});


### PR DESCRIPTION
## Why?

Regression caused by overzealous tidying of last PR

## What?
 deletes code from props used to writ to relationships