### PR TITLE
fix demo app sub-header

### DIFF
--- a/demo/cms/components/subheader.jsx
+++ b/demo/cms/components/subheader.jsx
@@ -1,51 +1,111 @@
 const React = require('react');
 
-const Subheader = ({ type, code, data }) => (
+const newTabLinkProps = url => {
+	if (String(url).startsWith('http')) {
+		return { rel: 'noopener noreferrer', target: '_blank' };
+	}
+	return {};
+};
+
+const AlternateViewLink = ({ url, ariaLabel, text }) => (
+	<>
+		<a
+			className="o-buttons o-buttons--secondary o-layout__unstyled-element o-buttons-icon o-buttons-icon--arrow-right"
+			href={url}
+			aria-label={ariaLabel}
+			{...newTabLinkProps(url)}
+		>
+			{text}
+		</a>{' '}
+	</>
+);
+
+const Subheader = ({
+	schema: { type },
+	data: { code, url, _lockedFields, runbookMdUrl, lastReleaseTimestamp },
+	data,
+}) => (
 	<div className="o-buttons__group">
 		{type === 'System' && data.lifecycleStage !== 'Decommissioned' ? (
 			<>
-				<a
-					className="o-buttons o-layout__unstyled-element"
-					href={`https://runbooks.in.ft.com/${encodeURIComponent(
+				<AlternateViewLink
+					url={`https://runbooks.in.ft.com/${encodeURIComponent(
 						code,
 					)}`}
-					aria-label={`edit ${code} in Biz-Ops Admin`}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					View runbook
-				</a>{' '}
-				<a
-					className="o-buttons o-buttons--secondary o-layout__unstyled-element"
-					href={`https://heimdall.in.ft.com/system?code=${encodeURIComponent(
+					ariaLabel={`Edit ${code} in Biz Ops Admin`}
+					text="Runbook"
+				/>
+				<AlternateViewLink
+					url={`https://heimdall.in.ft.com/system?code=${encodeURIComponent(
 						code,
 					)}`}
-					aria-label={`view the status of ${code} in Heimdall`}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					View Heimdall dashboard
-				</a>{' '}
-				<a
-					className="o-buttons o-buttons--secondary o-layout__unstyled-element"
-					href={`https://sos.in.ft.com/System/${encodeURIComponent(
+					ariaLabel={`View the status of ${code} in Heimdall`}
+					text="Heimdall dashboard"
+				/>
+
+				<AlternateViewLink
+					url={`https://sos.in.ft.com/System/${encodeURIComponent(
 						code,
 					)}`}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					View SOS rating
-				</a>
+					ariaLabel={`See the system operability score for ${code}`}
+					text="SOS rating"
+				/>
+				{lastReleaseTimestamp ? (
+					<AlternateViewLink
+						url={`https://changes.in.ft.com/?systems=${code}`}
+						ariaLabel="View recent change logs for this system"
+						text="Changes"
+					/>
+				) : null}
+				{/biz-ops-runbook-md/.test(_lockedFields) ? null : (
+					<AlternateViewLink
+						url={`https://biz-ops.in.ft.com/runbook.md/export?systemCode=${encodeURIComponent(
+							code,
+						)}`}
+						ariaLabel={`Create a RUNBOOK.md file to maintain this system's information in`}
+						text="Create RUNBOOK.md"
+					/>
+				)}
+
+				{runbookMdUrl ? (
+					<AlternateViewLink
+						url={runbookMdUrl}
+						ariaLabel={`Visit the System's RUNBOOK.md file to edit this system's information`}
+						text="Edit RUNBOOK.md"
+					/>
+				) : null}
 			</>
 		) : null}
-		<a
-			className="o-buttons o-buttons--secondary o-layout__unstyled-element biz-ops-cta--visualise"
-			href={`/${type}/${encodeURIComponent(code)}/visualise`}
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			Visualise
-		</a>
+		{type === 'Person' && data.isPeopleApi ? (
+			<>
+				<AlternateViewLink
+					url={`https://people-finder.in.ft.com/search?name=${encodeURIComponent(
+						code,
+					)}`}
+					ariaLabel="More about this staff member in people finder"
+					text="People finder"
+				/>
+				<AlternateViewLink
+					url={`https://people-finder.in.ft.com/org/${encodeURIComponent(
+						code,
+					)}`}
+					ariaLabel="View this person's org chart in people-finder"
+					text="Org chart"
+				/>
+			</>
+		) : null}
+		{type === 'Repository' && data.versionControlSystem === 'github' ? (
+			<AlternateViewLink
+				url={url}
+				ariaLabel="See this repository in Github"
+				text="Github"
+			/>
+		) : null}
+		<AlternateViewLink
+			url={`/${type}/${encodeURIComponent(code)}/visualise`}
+			ariaLabel={`Visualise the connections to ${code}`}
+			text="GraphViz"
+		/>
 	</div>
 );
 


### PR DESCRIPTION
## Why?

- The current [implementation](https://github.com/Financial-Times/treecreeper/blob/303450a27da90afc9ef913f40c1397e33cd7f9cd/demo/cms/components/subheader.jsx#L3) of demo app's `Subheader` component is not working properly when we hookup treecreeper with Biz Ops. The reason for this is when we distructure properties form the prop `type` is undefined as it is not defined in the root but as
```
{
    schema: {
        type: "System"
        ...
    }
}
```

## What?

-   replaced the `Subheader` component with the one that is implemented in Biz-ops-admin

## Screenshots / Images

### Before
<img width="1237" alt="Screenshot 2020-03-25 at 12 48 36" src="https://user-images.githubusercontent.com/9718606/77539921-0ec48300-6e9a-11ea-900b-e9003d31bc6a.png">

### After
<img width="1220" alt="Screenshot 2020-03-25 at 12 50 18" src="https://user-images.githubusercontent.com/9718606/77539937-17b55480-6e9a-11ea-8be2-c5e9cd3a2dab.png">


