### PR TITLE
fixed request tracing (I hope)

### DIFF
--- a/packages/tc-api-graphql/lib/request-tracer.js
+++ b/packages/tc-api-graphql/lib/request-tracer.js
@@ -17,10 +17,10 @@ class Tracer {
 			Object.entries(this.map).forEach(([type, fields]) => {
 				let properties;
 				try {
-					({ properties } = getType(type))
-				} catch {
+					({ properties } = getType(type));
+				} catch (err) {
 					properties = {};
-				};
+				}
 				fields = [...fields];
 				logger[logType]({
 					event: 'GRAPHQL_TRACE',

--- a/packages/tc-api-graphql/lib/request-tracer.js
+++ b/packages/tc-api-graphql/lib/request-tracer.js
@@ -15,7 +15,12 @@ class Tracer {
 	_log(logType) {
 		try {
 			Object.entries(this.map).forEach(([type, fields]) => {
-				const { properties } = getType(type);
+				let properties;
+				try {
+					({ properties } = getType(type))
+				} catch {
+					properties = {};
+				};
 				fields = [...fields];
 				logger[logType]({
 					event: 'GRAPHQL_TRACE',


### PR DESCRIPTION
## Why?

Request tracing has been broken for a while, which means we have zero visibility of which fields are safe to delete from GraphQL

## What?

Kiya found an interesting looking log https://trello.com/c/8annX6pE/2-comprehensive-graphql-tracing, which revealed that trying to do checks for deprecated fields on neo4j-graphql-js's generated types was causing errors to be thrown. This meant the entire trace for all types errored and we got no data.

This is now wrapped in a try catch, and trace logs are coming through:
![image](https://user-images.githubusercontent.com/447559/77628947-a7add980-6f40-11ea-89ef-c8fc3331d512.png)
