### PR TITLE
allow passing extra resolvers and schema extensions

### DIFF
--- a/packages/tc-api-express/README.md
+++ b/packages/tc-api-express/README.md
@@ -67,6 +67,33 @@ Array of middlewares to call before the relevant REST handler executes
 
 An [optional] reference to a tc-api-s3-document-store instance (or a library implementing the same API), used to store large properties outside the neo4j instance
 
+##### `options`
+
+An [optional] object value for adding extra resolvers and typeDefs. It should have the following data structure
+
+```
+{
+  options: {
+    typeDefs: [
+      `type ExtendedType {
+        code: String
+        someString: String
+        someFloat: Float
+        someEnum: AnEnum
+      }`,
+      `extend type MainType {
+        extended: ExtendedType @neo4j_ignore *
+        }`,],
+    resolvers: {
+      MainType: {
+        extended: () => { ...custom resolver },
+      },
+    },
+  }
+}
+```
+*\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process*
+
 ##### `republishSchema`
 
 A boolean indicating whether the application needs to republish the schema to somewhere once it has updated the graphqlApi. Note that republishing depends on a `TREECREEPER_SCHEMA_BUCKET` envioronment variable, which should be the name of an s3 bucket.

--- a/packages/tc-api-express/README.md
+++ b/packages/tc-api-express/README.md
@@ -67,32 +67,41 @@ Array of middlewares to call before the relevant REST handler executes
 
 An [optional] reference to a tc-api-s3-document-store instance (or a library implementing the same API), used to store large properties outside the neo4j instance
 
-##### `options`
+##### `typeDefs`
 
-An [optional] object value for adding extra resolvers and typeDefs. It should have the following data structure
+An [optional] array value for extending the existing type definitions
 
 ```
 {
-  options: {
-    typeDefs: [
-      `type ExtendedType {
-        code: String
-        someString: String
-        someFloat: Float
-        someEnum: AnEnum
-      }`,
-      `extend type MainType {
-        extended: ExtendedType @neo4j_ignore *
-        }`,],
-    resolvers: {
-      MainType: {
-        extended: () => { ...custom resolver },
-      },
-    },
-  }
+  typeDefs: [
+    `type ExtendedType {
+      code: String
+      someString: String
+      someFloat: Float
+      someEnum: AnEnum
+    }`,
+    `extend type MainType {
+      extended: ExtendedType @neo4j_ignore *
+    }`,
+  ],
 }
 ```
-*\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process*
+
+_\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process_
+
+##### `resolvers`
+
+An [optional] object value for adding extra/custom resolvers
+
+```
+{
+  resolvers: {
+    MainType: {
+      extended: () => { ...custom resolver },
+    },
+  },
+}
+```
 
 ##### `republishSchema`
 

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -48,7 +48,7 @@ An [optional] object value for adding extra resolvers and typeDefs. It should ha
         someEnum: AnEnum
       }`,
       `extend type MainType {
-        extended: ExtendedType @neo4j_ignore
+        extended: ExtendedType @neo4j_ignore *
         }`,],
     resolvers: {
       MainType: {
@@ -58,6 +58,7 @@ An [optional] object value for adding extra resolvers and typeDefs. It should ha
   }
 }
 ```
+*\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process*
 
 ## Example
 

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -33,32 +33,41 @@ A boolean indicating whether the application needs to republish the schema to so
 If the application needs to republish the schema to somewhere once it has updated the graphqlApi, this string indicates the
 prefix to use
 
-#### `options`
+#### `typeDefs`
 
-An [optional] object value for adding extra resolvers and typeDefs. It should have the following data structure
+An [optional] array value for extending the existing type definitions
 
 ```
 {
-  options: {
-    typeDefs: [
-      `type ExtendedType {
-        code: String
-        someString: String
-        someFloat: Float
-        someEnum: AnEnum
-      }`,
-      `extend type MainType {
-        extended: ExtendedType @neo4j_ignore *
-        }`,],
-    resolvers: {
-      MainType: {
-        extended: () => { ...custom resolver },
-      },
-    },
-  }
+  typeDefs: [
+    `type ExtendedType {
+      code: String
+      someString: String
+      someFloat: Float
+      someEnum: AnEnum
+    }`,
+    `extend type MainType {
+      extended: ExtendedType @neo4j_ignore *
+    }`,
+  ],
 }
 ```
-*\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process*
+
+_\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process_
+
+#### `resolvers`
+
+An [optional] object value for adding extra/custom resolvers
+
+```
+{
+  resolvers: {
+    MainType: {
+      extended: () => { ...custom resolver },
+    },
+  },
+}
+```
 
 ## Example
 

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -26,12 +26,38 @@ An [optional] reference to a tc-api-s3-document-store instance (or a library imp
 
 ##### `republishSchema`
 
-A boolean indicating whether the application needs to republish the schema to somewhere once it has updated the graphqlApi. Note that republishing depends on a `TREECREEPER_SCHEMA_BUCKET` envioronment variable, which should be the name of an s3 bucket.
+A boolean indicating whether the application needs to republish the schema to somewhere once it has updated the graphqlApi. Note that republishing depends on a `TREECREEPER_SCHEMA_BUCKET` environment variable, which should be the name of an s3 bucket.
 
 ##### `republishSchemaPrefix = 'api'`
 
 If the application needs to republish the schema to somewhere once it has updated the graphqlApi, this string indicates the
 prefix to use
+
+#### `options`
+
+An [optional] object value for adding extra resolvers and typeDefs. It should have the following data structure
+
+```
+{
+  options: {
+    typeDefs: [
+      `type ExtendedType {
+        code: String
+        someString: String
+        someFloat: Float
+        someEnum: AnEnum
+      }`,
+      `extend type MainType {
+        extended: ExtendedType @neo4j_ignore
+        }`,],
+    resolvers: {
+      MainType: {
+        extended: () => { ...custom resolver },
+      },
+    },
+  }
+}
+```
 
 ## Example
 

--- a/packages/tc-api-graphql/__tests__/graphql.spec.js
+++ b/packages/tc-api-graphql/__tests__/graphql.spec.js
@@ -297,27 +297,25 @@ describe('graphql', () => {
 				graphqlHandler,
 				listenForSchemaChanges: updateGraphqlApiOnSchemaChange,
 			} = getGraphqlApi({
-				options: {
-					typeDefs: [
-						`type ExtendedType {
+				typeDefs: [
+					`type ExtendedType {
 							code: String
 							someString: String
 							someFloat: Float
 							someEnum: AnEnum
 						}`,
-						`extend type MainType {
+					`extend type MainType {
 					extended: ExtendedType @neo4j_ignore
 			   }`,
-					],
-					resolvers: {
-						MainType: {
-							extended: () => ({
-								code: `${namespace}-extend`,
-								someString: 'some string',
-								someFloat: 20.21,
-								someEnum: 'First',
-							}),
-						},
+				],
+				resolvers: {
+					MainType: {
+						extended: () => ({
+							code: `${namespace}-extend`,
+							someString: 'some string',
+							someFloat: 20.21,
+							someEnum: 'First',
+						}),
 					},
 				},
 			});

--- a/packages/tc-api-graphql/__tests__/graphql.spec.js
+++ b/packages/tc-api-graphql/__tests__/graphql.spec.js
@@ -287,4 +287,76 @@ describe('graphql', () => {
 			});
 		});
 	});
+
+	describe('with extended typeDef and resolvers', () => {
+		let testApp;
+
+		beforeAll(() => {
+			testApp = express();
+			const {
+				graphqlHandler,
+				listenForSchemaChanges: updateGraphqlApiOnSchemaChange,
+			} = getGraphqlApi({
+				options: {
+					typeDefs: [
+						`type ExtendedType {
+							code: String
+							someString: String
+							someFloat: Float
+							someEnum: AnEnum
+						}`,
+						`extend type MainType {
+					extended: ExtendedType @neo4j_ignore
+			   }`,
+					],
+					resolvers: {
+						MainType: {
+							extended: () => ({
+								code: `${namespace}-extend`,
+								someString: 'some string',
+								someFloat: 20.21,
+								someEnum: 'First',
+							}),
+						},
+					},
+				},
+			});
+
+			updateGraphqlApiOnSchemaChange();
+			testApp.post('/graphql', graphqlHandler);
+		});
+
+		it('returns data from extended resolver', async () => {
+			await createNode('MainType', {
+				code: mainCode,
+			});
+			return request(testApp)
+				.post('/graphql')
+				.send({
+					query: `{
+					MainType(filter: {code: "${mainCode}"}) {
+						code
+						extended {
+							code
+							someString
+							someFloat
+							someEnum
+						}
+					}}`,
+				})
+				.expect(200, {
+					data: {
+						MainType: {
+							code: mainCode,
+							extended: {
+								code: `${namespace}-extend`,
+								someString: 'some string',
+								someFloat: 20.21,
+								someEnum: 'First',
+							},
+						},
+					},
+				});
+		});
+	});
 });

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -7,13 +7,14 @@ const getGraphqlApi = ({
 	documentStore,
 	republishSchema,
 	republishSchemaPrefix = 'api',
+	options = {},
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
 
 	const updateAPI = () => {
 		try {
-			graphqlHandler = getApolloMiddleware({ documentStore });
+			graphqlHandler = getApolloMiddleware({ documentStore, options });
 
 			schemaDidUpdate = true;
 			logger.info({ event: 'GRAPHQL_SCHEMA_UPDATED' });

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -7,14 +7,19 @@ const getGraphqlApi = ({
 	documentStore,
 	republishSchema,
 	republishSchemaPrefix = 'api',
-	options = {},
+	typeDefs = [],
+	resolvers = {},
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
 
 	const updateAPI = () => {
 		try {
-			graphqlHandler = getApolloMiddleware({ documentStore, options });
+			graphqlHandler = getApolloMiddleware({
+				documentStore,
+				typeDefs,
+				resolvers,
+			});
 
 			schemaDidUpdate = true;
 			logger.info({ event: 'GRAPHQL_SCHEMA_UPDATED' });

--- a/packages/tc-api-graphql/lib/get-apollo-middleware.js
+++ b/packages/tc-api-graphql/lib/get-apollo-middleware.js
@@ -8,10 +8,10 @@ const { driver } = require('@financial-times/tc-api-db-manager');
 const { getAugmentedSchema } = require('./get-augmented-schema');
 const { Tracer } = require('./request-tracer');
 
-const getApolloMiddleware = ({ documentStore }) => {
+const getApolloMiddleware = ({ documentStore, options }) => {
 	const apollo = new ApolloServer({
 		subscriptions: false,
-		schema: getAugmentedSchema({ documentStore }),
+		schema: getAugmentedSchema({ documentStore, options }),
 		context: ({
 			req: { headers },
 			res: {

--- a/packages/tc-api-graphql/lib/get-apollo-middleware.js
+++ b/packages/tc-api-graphql/lib/get-apollo-middleware.js
@@ -8,10 +8,10 @@ const { driver } = require('@financial-times/tc-api-db-manager');
 const { getAugmentedSchema } = require('./get-augmented-schema');
 const { Tracer } = require('./request-tracer');
 
-const getApolloMiddleware = ({ documentStore, options }) => {
+const getApolloMiddleware = ({ documentStore, typeDefs, resolvers }) => {
 	const apollo = new ApolloServer({
 		subscriptions: false,
-		schema: getAugmentedSchema({ documentStore, options }),
+		schema: getAugmentedSchema({ documentStore, typeDefs, resolvers }),
 		context: ({
 			req: { headers },
 			res: {

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -38,8 +38,8 @@ const getAugmentedSchema = ({ documentStore, options }) => {
 	const resolvers = documentStore ? getDocumentResolvers() : {};
 	const typeDefs = getGraphqlDefs();
 
-	if (options.schema) {
-		typeDefs.push(options.schema);
+	if (options.typeDefs) {
+		typeDefs.push(...options.typeDefs);
 	}
 	if (options.resolvers) {
 		// add custom resolvers

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -34,8 +34,18 @@ const getDocumentResolvers = () => {
 	return typeResolvers;
 };
 
-const getAugmentedSchema = ({ documentStore }) => {
+const getAugmentedSchema = ({ documentStore, options }) => {
+	const resolvers = documentStore ? getDocumentResolvers() : {};
 	const typeDefs = getGraphqlDefs();
+
+	if (options.schema) {
+		typeDefs.push(options.schema);
+	}
+	if (options.resolvers) {
+		// add custom resolvers
+		Object.assign(resolvers, { ...options.resolvers });
+	}
+
 	// this should throw meaningfully if the defs are invalid;
 	parse(typeDefs.join('\n'));
 
@@ -48,8 +58,12 @@ const getAugmentedSchema = ({ documentStore }) => {
 				});
 			},
 		},
-		resolvers: documentStore ? getDocumentResolvers() : {},
-		config: { query: true, mutation: false, debug: true },
+		resolvers,
+		config: {
+			query: true,
+			mutation: false,
+			debug: true,
+		},
 	});
 
 	return applyMiddleware(schema, requestTracer);

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -34,16 +34,20 @@ const getDocumentResolvers = () => {
 	return typeResolvers;
 };
 
-const getAugmentedSchema = ({ documentStore, options }) => {
+const getAugmentedSchema = ({
+	documentStore,
+	typeDefs: extendedTypeDefs,
+	resolvers: extendedResolvers,
+}) => {
 	const resolvers = documentStore ? getDocumentResolvers() : {};
 	const typeDefs = getGraphqlDefs();
 
-	if (options.typeDefs) {
-		typeDefs.push(...options.typeDefs);
+	if (extendedTypeDefs.length) {
+		typeDefs.push(...extendedTypeDefs);
 	}
-	if (options.resolvers) {
+	if (Object.keys(extendedResolvers).length) {
 		// add custom resolvers
-		Object.assign(resolvers, { ...options.resolvers });
+		Object.assign(resolvers, { ...extendedResolvers });
 	}
 
 	// this should throw meaningfully if the defs are invalid;


### PR DESCRIPTION
## Why?

-   Allow passing in extra resolvers and schema extensions as options in to [tc-api-graphql](https://trello.com/c/sWJrp982/282-allow-passing-in-extra-resolvers-and-schema-extensions-as-options-in-to-tc-api-graphql) 

## What?

-   added `options` argument 
```
{
 ...,
 options: {
  schema: [...],
  resolvers: {...}
}
```
- [ ] update documentation  
