### PR TITLE
allow adding line breaks in nested propdefs

### DIFF
--- a/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
+++ b/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
@@ -52,6 +52,31 @@ describe('nested property definition tests', () => {
 				},
 			});
 		});
+
+		it('can be parsed as object which additional property definitions with extra spaces', async () => {
+			const { data, errors } = await parser.parseMarkdownString(here`
+				# name
+
+				## curious child
+
+				${`example-code
+					someString: i like it
+					someBoolean: yes`
+					.replace(/\t+/g, '\t')
+					.split('\n')
+					.join('  \n')}
+			`);
+
+			expect(errors).toHaveLength(0);
+			expect(data).toEqual({
+				name: 'name',
+				curiousChild: {
+					code: 'example-code',
+					someString: 'i like it',
+					someBoolean: true,
+				},
+			});
+		});
 	});
 
 	describe('boolean type conversion', () => {

--- a/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
+++ b/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
@@ -11,6 +11,14 @@ const parser = getParser({
 	type: 'MainType',
 });
 
+// The weird string concatenation in the markdown fixture is so that
+// dev tooling doesn't tidy up the 'extraneous' whitespace
+const addLineBreaks = str =>
+	str
+		.replace(/\t+/g, '\t')
+		.split('\n')
+		.join('  \n');
+
 describe('nested property definition tests', () => {
 	describe('single relationship case - hasMany: false', () => {
 		it('can be parsed only code definition as an object', async () => {
@@ -53,18 +61,15 @@ describe('nested property definition tests', () => {
 			});
 		});
 
-		it('can be parsed as object which additional property definitions with extra spaces', async () => {
+		it('can be parsed as object which additional property definitions with line breaks', async () => {
 			const { data, errors } = await parser.parseMarkdownString(here`
 				# name
 
 				## curious child
 
-				${`example-code
+				${addLineBreaks(`example-code
 					someString: i like it
-					someBoolean: yes`
-					.replace(/\t+/g, '\t')
-					.split('\n')
-					.join('  \n')}
+					someBoolean: yes`)}
 			`);
 
 			expect(errors).toHaveLength(0);
@@ -478,6 +483,41 @@ describe('nested property definition tests', () => {
 				- example-code02
 					someString: i like it, too
 					someBoolean: no
+			`);
+
+			expect(errors).toHaveLength(0);
+			expect(data).toEqual({
+				name: 'name',
+				isCuriousChildOf: [
+					{
+						code: 'example-code01',
+						someString: 'i like it',
+						someBoolean: true,
+					},
+					{
+						code: 'example-code02',
+						someString: 'i like it, too',
+						someBoolean: false,
+					},
+				],
+			});
+		});
+
+		it('can be parsed as Array of objects with additional property definitions with line breaks', async () => {
+			const childParser = getParser({
+				type: 'ChildType',
+			});
+			const { data, errors } = await childParser.parseMarkdownString(here`
+				# name
+
+				## is curious child of
+
+				${addLineBreaks(`- example-code01
+					someString: i like it
+					someBoolean: yes`)}
+				${addLineBreaks(`- example-code02
+					someString: i like it, too
+					someBoolean: no`)}
 			`);
 
 			expect(errors).toHaveLength(0);


### PR DESCRIPTION
## Why?
To make relationship properties in runbook.md more legible, it's nice to add extra spaces in order to create line breaks. Unfortunately this leads to a different AST generated by the markdown parser, and therefore the parsing into properties on relationships broke (silently, I might add - the properties ended up getting completely discarded due to some quirk of the parser).

## What?
Takes a list of text - break - text - break - text nodes and compresses into a single text node where the value contains new lines. Part of me thinks it'd be more elegant to go the other way - take ones without line breaks and split them out into a tree that includes breaks before continuing with parsing. But that feels like it has potential to be an enormous yak shave.

It's worth noting that, in theory, the first node in the list might not have a text value and this would break. I don't actually think this is possible, and the code is being too defensive. Tests still all pass and we'll just have to keep an eye out for users complaining