### PR TITLE
add ability to exclude types from neo4j augmentation

### DIFF
--- a/packages/tc-api-express/README.md
+++ b/packages/tc-api-express/README.md
@@ -69,39 +69,13 @@ An [optional] reference to a tc-api-s3-document-store instance (or a library imp
 
 ##### `typeDefs`
 
-An [optional] array value for extending the existing type definitions
-
-```
-{
-  typeDefs: [
-    `type ExtendedType {
-      code: String
-      someString: String
-      someFloat: Float
-      someEnum: AnEnum
-    }`,
-    `extend type MainType {
-      extended: ExtendedType @neo4j_ignore *
-    }`,
-  ],
-}
-```
-
-_\* **@neo4j_ignore** must be added so that it is not used during the schema augmentation process_
+See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/blob/master/packages/tc-api-graphql/README.md)
 
 ##### `resolvers`
 
-An [optional] object value for adding extra/custom resolvers
-
-```
-{
-  resolvers: {
-    MainType: {
-      extended: () => { ...custom resolver },
-    },
-  },
-}
-```
+See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/blob/master/packages/tc-api-graphql/README.md)
+##### `excludeTypes`
+See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/blob/master/packages/tc-api-graphql/README.md)
 
 ##### `republishSchema`
 

--- a/packages/tc-api-express/README.md
+++ b/packages/tc-api-express/README.md
@@ -74,7 +74,9 @@ See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/b
 ##### `resolvers`
 
 See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/blob/master/packages/tc-api-graphql/README.md)
+
 ##### `excludeTypes`
+
 See the [tc-api-graphql README](https://github.com/Financial-Times/treecreeper/blob/master/packages/tc-api-graphql/README.md)
 
 ##### `republishSchema`

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -69,6 +69,9 @@ An [optional] object value for adding extra/custom resolvers
 }
 ```
 
+#### `excludeTypes`
+An [optional] array of type names to exclude from neo4j-graphql-js augmentation. This should list all types which get data from sources other than the neo4j
+
 ## Example
 
 ```js

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -70,6 +70,7 @@ An [optional] object value for adding extra/custom resolvers
 ```
 
 #### `excludeTypes`
+
 An [optional] array of type names to exclude from neo4j-graphql-js augmentation. This should list all types which get data from sources other than the neo4j
 
 ## Example

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -9,6 +9,7 @@ const getGraphqlApi = ({
 	republishSchemaPrefix = 'api',
 	typeDefs = [],
 	resolvers = {},
+	excludeTypes
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
@@ -19,6 +20,7 @@ const getGraphqlApi = ({
 				documentStore,
 				typeDefs,
 				resolvers,
+				excludeTypes
 			});
 
 			schemaDidUpdate = true;

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -9,7 +9,7 @@ const getGraphqlApi = ({
 	republishSchemaPrefix = 'api',
 	typeDefs = [],
 	resolvers = {},
-	excludeTypes
+	excludeTypes,
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
@@ -20,7 +20,7 @@ const getGraphqlApi = ({
 				documentStore,
 				typeDefs,
 				resolvers,
-				excludeTypes
+				excludeTypes,
 			});
 
 			schemaDidUpdate = true;

--- a/packages/tc-api-graphql/lib/get-apollo-middleware.js
+++ b/packages/tc-api-graphql/lib/get-apollo-middleware.js
@@ -8,10 +8,10 @@ const { driver } = require('@financial-times/tc-api-db-manager');
 const { getAugmentedSchema } = require('./get-augmented-schema');
 const { Tracer } = require('./request-tracer');
 
-const getApolloMiddleware = ({ documentStore, typeDefs, resolvers }) => {
+const getApolloMiddleware = ({ documentStore, typeDefs, resolvers, excludeTypes }) => {
 	const apollo = new ApolloServer({
 		subscriptions: false,
-		schema: getAugmentedSchema({ documentStore, typeDefs, resolvers }),
+		schema: getAugmentedSchema({ documentStore, typeDefs, resolvers, excludeTypes }),
 		context: ({
 			req: { headers },
 			res: {

--- a/packages/tc-api-graphql/lib/get-apollo-middleware.js
+++ b/packages/tc-api-graphql/lib/get-apollo-middleware.js
@@ -8,10 +8,20 @@ const { driver } = require('@financial-times/tc-api-db-manager');
 const { getAugmentedSchema } = require('./get-augmented-schema');
 const { Tracer } = require('./request-tracer');
 
-const getApolloMiddleware = ({ documentStore, typeDefs, resolvers, excludeTypes }) => {
+const getApolloMiddleware = ({
+	documentStore,
+	typeDefs,
+	resolvers,
+	excludeTypes,
+}) => {
 	const apollo = new ApolloServer({
 		subscriptions: false,
-		schema: getAugmentedSchema({ documentStore, typeDefs, resolvers, excludeTypes }),
+		schema: getAugmentedSchema({
+			documentStore,
+			typeDefs,
+			resolvers,
+			excludeTypes,
+		}),
 		context: ({
 			req: { headers },
 			res: {

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -38,7 +38,7 @@ const getAugmentedSchema = ({
 	documentStore,
 	typeDefs: extendedTypeDefs,
 	resolvers: extendedResolvers,
-	excludeTypes
+	excludeTypes,
 }) => {
 	const resolvers = documentStore ? getDocumentResolvers() : {};
 	const typeDefs = getGraphqlDefs();
@@ -65,7 +65,7 @@ const getAugmentedSchema = ({
 		},
 		resolvers,
 		config: {
-			query: excludeTypes ? {exclude: excludeTypes} : true,
+			query: excludeTypes ? { exclude: excludeTypes } : true,
 			mutation: false,
 			debug: true,
 		},

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -38,6 +38,7 @@ const getAugmentedSchema = ({
 	documentStore,
 	typeDefs: extendedTypeDefs,
 	resolvers: extendedResolvers,
+	excludeTypes
 }) => {
 	const resolvers = documentStore ? getDocumentResolvers() : {};
 	const typeDefs = getGraphqlDefs();
@@ -64,7 +65,7 @@ const getAugmentedSchema = ({
 		},
 		resolvers,
 		config: {
-			query: true,
+			query: excludeTypes ? {exclude: excludeTypes} : true,
 			mutation: false,
 			debug: true,
 		},


### PR DESCRIPTION
## Why?

If using a custom resolver to populate types they must be excluded from neo4j schema augmentation

## What?
Adds an option to be passed from tc-api-express down to tc-api-graphql. Also dedupes some README docs.