### PR TITLE
Enable markdown in the field descriptions!

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -479,6 +479,17 @@ ignore:
     - '@financial-times/tc-ui > showdown > yargs > yargs-parser':
         reason: no fix yet
         expires: '2020-04-23T12:54:36.605Z'
-
+  SNYK-JS-LODASH-567746:
+    - next-metrics > lodash:
+        reason: Wait for lodash fix
+        expires: '2020-05-31T15:33:56.703Z'
+    - neo4j-graphql-js > lodash:
+        reason: Wait for lodash fix
+        expires: '2020-05-31T15:33:56.703Z'
+    - '@financial-times/tc-api-db-manager > next-metrics > lodash':
+        reason: Wait for lodash fix
+        expires: '2020-05-31T15:33:56.703Z'
+    - '@financial-times/tc-api-rest-handlers > @financial-times/tc-api-db-manager > next-metrics > lodash':
+        reason: Wait for lodash fix
+        expires: '2020-05-31T15:33:56.703Z'
 patch: {}
-

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -34,7 +34,7 @@ const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
 						more info
 					</button>
 					<div className="o-expander__content">
-						{markdownToHtml(expandableContent)}
+						{expandableContent}
 					</div>
 				</div>
 			) : null}

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -6,7 +6,7 @@ const { LinkToRecord } = require('./structure');
 const FieldTitle = ({ label, description, expandableContent, lockedBy }) => {
 	const converter = new showdown.Converter();
 	const descriptionHTML = converter.makeHtml(description);
-	const expandableContentHTML = converter.makeHtml(expandableContent);
+	const expandableContentHTML = expandableContent ? converter.makeHtml(expandableContent) : undefined;
 	return (
 		<span className="o-forms-title">
 			<span

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -1,9 +1,14 @@
 const React = require('react');
 const autolinker = require('autolinker');
+const showdown = require('showdown');
 const { LinkToRecord } = require('./structure');
 
-const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
-	<span className="o-forms-title">
+const FieldTitle = ({ label, description, expandableContent, lockedBy }) => {
+	const converter = new showdown.Converter();
+	const descriptionHTML = converter.makeHtml(description);
+	const expandableContentHTML = converter.makeHtml(expandedContent);
+	return (
+		<span className="o-forms-title">
 		<span
 			className="o-forms-title__main"
 			id="inline-radio-round-group-title"
@@ -16,9 +21,9 @@ const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
 				dangerouslySetInnerHTML={{
 					__html:
 						typeof window === 'undefined'
-							? autolinker.link(description)
+							? autolinker.link(descriptionHTML)
 							: // eslint-disable-next-line no-undef
-							  Autolinker.link(description),
+							Autolinker.link(descriptionHTML),
 				}}
 			/>
 			{expandableContent ? (
@@ -37,7 +42,7 @@ const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
 						more info
 					</button>
 					<div className="o-expander__content">
-						{expandableContent}
+						{expandableContentHTML}
 					</div>
 				</div>
 			) : null}
@@ -49,7 +54,8 @@ const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
 			) : null}
 		</span>
 	</span>
-);
+	)
+};
 
 const WrappedEditComponent = props => {
 	props = { ...props, disabled: !!props.lockedBy };

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -1,65 +1,52 @@
 const React = require('react');
-const autolinker = require('autolinker');
-const showdown = require('showdown');
+const { markdownToHtml } = require('../markdown-to-html');
+
 const { LinkToRecord } = require('./structure');
 
-const FieldTitle = ({ label, description, expandableContent, lockedBy }) => {
-	const converter = new showdown.Converter();
-	const descriptionHTML = converter.makeHtml(description);
-	const expandableContentHTML = expandableContent ? converter.makeHtml(expandableContent) : undefined;
-	return (
-		<span className="o-forms-title">
-			<span
-				className="o-forms-title__main"
-				id="inline-radio-round-group-title"
-			>
-				{label}:
-			</span>
-
-			<span className="o-forms-title__prompt description-text">
-				<span
-					dangerouslySetInnerHTML={{
-						__html:
-							typeof window === 'undefined'
-								? autolinker.link(descriptionHTML)
-								: // eslint-disable-next-line no-undef
-								  Autolinker.link(descriptionHTML),
-					}}
-				/>
-				{expandableContent ? (
-					<div
-						data-o-component="o-expander"
-						className="o-expander"
-						data-o-expander-shrink-to="hidden"
-						data-o-expander-collapsed-toggle-text="more info"
-						data-o-expander-expanded-toggle-text="less"
-					>
-						{' '}
-						<button
-							className="o-expander__toggle o--if-js"
-							type="button"
-						>
-							more info
-						</button>
-						<div className="o-expander__content">
-							{expandableContentHTML}
-						</div>
-					</div>
-				) : null}
-				{lockedBy ? (
-					<div className="o-forms__additional-info">
-						Not editable. Automatically populated by{' '}
-						<LinkToRecord
-							type="System"
-							value={{ code: lockedBy }}
-						/>
-						.
-					</div>
-				) : null}
-			</span>
+const FieldTitle = ({ label, description, expandableContent, lockedBy }) => (
+	<span className="o-forms-title">
+		<span
+			className="o-forms-title__main"
+			id="inline-radio-round-group-title"
+		>
+			{label}:
 		</span>
-	);
-};
+
+		<span className="o-forms-title__prompt description-text">
+			<span
+				dangerouslySetInnerHTML={{
+					__html: markdownToHtml(description),
+				}}
+			/>
+			{expandableContent ? (
+				<div
+					data-o-component="o-expander"
+					className="o-expander"
+					data-o-expander-shrink-to="hidden"
+					data-o-expander-collapsed-toggle-text="more info"
+					data-o-expander-expanded-toggle-text="less"
+				>
+					{' '}
+					<button
+						className="o-expander__toggle o--if-js"
+						type="button"
+					>
+						more info
+					</button>
+					<div className="o-expander__content">
+						{markdownToHtml(expandableContent)}
+					</div>
+				</div>
+			) : null}
+			{lockedBy ? (
+				<div className="o-forms__additional-info">
+					Not editable. Automatically populated by{' '}
+					<LinkToRecord type="System" value={{ code: lockedBy }} />.
+				</div>
+			) : null}
+		</span>
+	</span>
+);
 
 const WrappedEditComponent = props => {
 	props = { ...props, disabled: !!props.lockedBy };

--- a/packages/tc-ui/src/lib/components/input-wrapper.jsx
+++ b/packages/tc-ui/src/lib/components/input-wrapper.jsx
@@ -6,55 +6,59 @@ const { LinkToRecord } = require('./structure');
 const FieldTitle = ({ label, description, expandableContent, lockedBy }) => {
 	const converter = new showdown.Converter();
 	const descriptionHTML = converter.makeHtml(description);
-	const expandableContentHTML = converter.makeHtml(expandedContent);
+	const expandableContentHTML = converter.makeHtml(expandableContent);
 	return (
 		<span className="o-forms-title">
-		<span
-			className="o-forms-title__main"
-			id="inline-radio-round-group-title"
-		>
-			{label}:
-		</span>
-
-		<span className="o-forms-title__prompt description-text">
 			<span
-				dangerouslySetInnerHTML={{
-					__html:
-						typeof window === 'undefined'
-							? autolinker.link(descriptionHTML)
-							: // eslint-disable-next-line no-undef
-							Autolinker.link(descriptionHTML),
-				}}
-			/>
-			{expandableContent ? (
-				<div
-					data-o-component="o-expander"
-					className="o-expander"
-					data-o-expander-shrink-to="hidden"
-					data-o-expander-collapsed-toggle-text="more info"
-					data-o-expander-expanded-toggle-text="less"
-				>
-					{' '}
-					<button
-						className="o-expander__toggle o--if-js"
-						type="button"
+				className="o-forms-title__main"
+				id="inline-radio-round-group-title"
+			>
+				{label}:
+			</span>
+
+			<span className="o-forms-title__prompt description-text">
+				<span
+					dangerouslySetInnerHTML={{
+						__html:
+							typeof window === 'undefined'
+								? autolinker.link(descriptionHTML)
+								: // eslint-disable-next-line no-undef
+								  Autolinker.link(descriptionHTML),
+					}}
+				/>
+				{expandableContent ? (
+					<div
+						data-o-component="o-expander"
+						className="o-expander"
+						data-o-expander-shrink-to="hidden"
+						data-o-expander-collapsed-toggle-text="more info"
+						data-o-expander-expanded-toggle-text="less"
 					>
-						more info
-					</button>
-					<div className="o-expander__content">
-						{expandableContentHTML}
+						{' '}
+						<button
+							className="o-expander__toggle o--if-js"
+							type="button"
+						>
+							more info
+						</button>
+						<div className="o-expander__content">
+							{expandableContentHTML}
+						</div>
 					</div>
-				</div>
-			) : null}
-			{lockedBy ? (
-				<div className="o-forms__additional-info">
-					Not editable. Automatically populated by{' '}
-					<LinkToRecord type="System" value={{ code: lockedBy }} />.
-				</div>
-			) : null}
+				) : null}
+				{lockedBy ? (
+					<div className="o-forms__additional-info">
+						Not editable. Automatically populated by{' '}
+						<LinkToRecord
+							type="System"
+							value={{ code: lockedBy }}
+						/>
+						.
+					</div>
+				) : null}
+			</span>
 		</span>
-	</span>
-	)
+	);
 };
 
 const WrappedEditComponent = props => {

--- a/packages/tc-ui/src/lib/markdown-to-html.js
+++ b/packages/tc-ui/src/lib/markdown-to-html.js
@@ -1,0 +1,18 @@
+const showdown = require('showdown');
+const autolinker = require('autolinker');
+
+showdown.setFlavor('github');
+
+const markdownParser = new showdown.Converter({
+	simplifiedAutoLink: true,
+});
+
+const markdownToHtml = text =>
+	typeof window === 'undefined'
+		? autolinker.link(markdownParser.makeHtml(text || ''))
+		: // eslint-disable-next-line no-undef
+		  Autolinker.link(markdownParser.makeHtml(text || ''));
+
+module.exports = {
+	markdownToHtml,
+};

--- a/packages/tc-ui/src/primitives/large-text/server.jsx
+++ b/packages/tc-ui/src/primitives/large-text/server.jsx
@@ -1,19 +1,6 @@
 const React = require('react');
-const showdown = require('showdown');
-const autolinker = require('autolinker');
 const { WrappedEditComponent } = require('../../lib/components/input-wrapper');
-
-showdown.setFlavor('github');
-
-const markdownParser = new showdown.Converter({
-	simplifiedAutoLink: true,
-});
-
-const markdown = text =>
-	typeof window === 'undefined'
-		? autolinker.link(markdownParser.makeHtml(text || ''))
-		: // eslint-disable-next-line no-undef
-		  Autolinker.link(markdownParser.makeHtml(text || ''));
+const { markdownToHtml } = require('../../lib/markdown-to-html');
 
 const outputFreeText = (text = '') => text;
 const localOnChange = (event, onChange) => {
@@ -87,7 +74,7 @@ module.exports = {
 	ViewComponent: ({ value, id }) => (
 		<section
 			id={id}
-			dangerouslySetInnerHTML={{ __html: markdown(value) }}
+			dangerouslySetInnerHTML={{ __html: markdownToHtml(value) }}
 		/>
 	),
 };


### PR DESCRIPTION
## Why?

We appear to have `markdown` syntax in our biz ops schema field descriptions but we just display them as raw text.

## What?

Call `showdown` to convert field descriptions from markdown to html.

### Anything in particular you'd like to highlight to reviewers?

Untested - as `make install` for this monorepo isnt completing on my windows machine at the moment

## Screenshots / Images

Add any Screenshots or Images here to show any change/s
