### PR TITLE
Tidied makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test:
 		then NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 \
 			jest --config="./jest.config.js" "${pkg}.*__tests__.*${spec}.*.spec.js" --testEnvironment=node --watch; \
 		else NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-			jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --maxWorkers=1 --ci --reporters=default --reporters=jest-junit --detectOpenHandles --forceExit; \
+			jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --runInBand --ci --reporters=default --reporters=jest-junit --detectOpenHandles --forceExit; \
 	fi
 
 ## Cypress stuff used in CI

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ verify:
 unprepublish:
 	sed s/"dist\/"/"src\/"/ packages/tc-ui/package.json > tmp && mv tmp packages/tc-ui/package.json
 
+## Note - no need to clean up ./packages/**/package-lock.json as they are installed lockless
+## https://github.com/Financial-Times/treecreeper/blob/master/package.json#L59
 clean-deps: unprepublish
 	rm -rf packages/*/node_modules
 	rm -rf node_modules

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,14 @@ node_modules/@financial-times/rel-engage/index.mk:
 LOCAL_BOLT_URL=bolt://localhost:7687
 BIZ_OPS_BOLT_URL=${NEO4J_BOLT_URL}
 NEO4J_VERSION=3.5.0
-
-
 PRODUCT_NAME=biz-ops
 PROJECT_NAME=biz-ops-api
 
+
+.PHONY: test
+
+
+# Install and dependency management
 env:
 	echo "No secret environment variables needed in test"
 
@@ -33,79 +36,56 @@ verify:
 unprepublish:
 	sed s/"dist\/"/"src\/"/ packages/tc-ui/package.json > tmp && mv tmp packages/tc-ui/package.json
 
+clean-deps: unprepublish
+	rm -rf packages/*/node_modules
+	rm -rf node_modules
+	rm package-lock.json
+	npm install
 
 # note that this invokes npm install, and in package.json there is a postinstall script
 # defined too, which installs all the node_modules for the packages
 install: unprepublish
 
-prepublish:
-	babel packages/tc-ui/src -D --out-dir packages/tc-ui/dist
-	sed s/"src\/"/"dist\/"/ packages/tc-ui/package.json > tmp && mv tmp packages/tc-ui/package.json
 
-monorepo-publish: prepublish
-	npx athloi version --concurrency 10 $(CIRCLE_TAG)
-	npx athloi publish --concurrency 10 -- --access public
+# Building and running
 
-.PHONY: test
-
-.PHONY: cypress-open
-cypress-open: ## cypress-open: Opens the Cypress.io Electron test runner. Expects a local application server to be running concurrently.
-	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress open
-
-.PHONY: cypress-run-page
-cypress-run-page:
-	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js"
-
-.PHONY: cypress-run-primitives
-cypress-run-primitives:
-	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js"
-
-.PHONY: cypress-verify
-cypress-verify:
-	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress verify
-
-deploy-aws:
-	aws cloudformation deploy --stack-name biz-ops-kinesis --template-body file://$(shell pwd)/aws/cloudformation/biz-ops-kinesis.yaml
-
-test:
-	@if [ -z $(CI) ]; \
-		then NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 \
-			jest --config="./jest.config.js" "${pkg}.*__tests__.*${spec}.*.spec.js" --testEnvironment=node --watch; \
-		else NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-			jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --maxWorkers=1 --ci --reporters=default --reporters=jest-junit --detectOpenHandles --forceExit; \
-	fi
-
-run-app: build-statics
-	NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema nodemon --inspect demo/api.js
-
+## Builds browser files for tc-ui (in watch mode when local)
 build-statics:
 	@if [ -z $(CI) ]; \
-		then $(info Webpack bundling modules ...) ./node_modules/.bin/webpack --mode=development; \
+		then $(info Webpack bundling modules ...) ./node_modules/.bin/webpack --mode=development --watch; \
 		else $(info Webpack bundling modules ...) webpack --mode=production; \
 	fi
 
 run-db:
 	docker-compose up
 
-run:
-	@concurrently "make run-db" "make run-app"
+run-app:
+	NEO4J_BOLT_URL=${LOCAL_BOLT_URL} \
+	TREECREEPER_TEST=true \
+	TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+	nodemon --inspect demo/api.js
 
+run-app-biz-ops:
+	WITH_DOCSTORE=true \
+	NEO4J_BOLT_URL=${BIZ_OPS_BOLT_URL} \
+	TREECREEPER_SCHEMA_URL=${SCHEMA_BASE_URL} \
+	nodemon --inspect demo/api.js
+
+run:
+	@concurrently "make run-db" "make run-app" "make build-statics"
+
+run-biz-ops:
+	@concurrently "make run-app-biz-ops" "make build-statics"
+
+
+# Testing & CI
+
+## Creates indexes on the DB
+## Run once before all tests in CI to avoid different spec runs from messing up the indexes whenever they init
 init-db:
 	NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_SCHEMA_DIRECTORY=example-schema packages/tc-api-db-manager/index.js
 
-cypress-page:
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page"
-
-cypress-primitives:
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives"
-
-run-biz-ops: build-statics
-	NEO4J_BOLT_URL=${BIZ_OPS_BOLT_URL} TREECREEPER_SCHEMA_URL=${SCHEMA_BASE_URL} PROJECT_NAME=biz-ops-api PRODUCT_NAME=biz-ops nodemon --inspect demo/api.js
-
+## Installs neo4j in CI
 run-test-db:
 	java -version; \
   mkdir -p neo4j; \
@@ -117,8 +97,52 @@ run-test-db:
   ./scripts/neo4j-wait-for-start;
 	make init-db
 
-clean-deps: unprepublish
-	rm -rf packages/*/node_modules
-	rm -rf node_modules
-	rm package-lock.json
-	npm install
+test:
+	@if [ -z $(CI) ]; \
+		then NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema DEBUG=true TIMEOUT=500000 \
+			jest --config="./jest.config.js" "${pkg}.*__tests__.*${spec}.*.spec.js" --testEnvironment=node --watch; \
+		else NEO4J_BOLT_URL=${LOCAL_BOLT_URL} TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+			jest --config="./jest.config.js" "__tests__.*/*.spec.js" --testEnvironment=node --maxWorkers=1 --ci --reporters=default --reporters=jest-junit --detectOpenHandles --forceExit; \
+	fi
+
+## Cypress stuff used in CI
+
+### Checks that cypress will be able to run ok
+cypress-verify:
+	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+	cypress verify
+
+### Runs tests for pages
+cypress-page: build-statics
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page"
+
+### Runs tests for primitive components
+cypress-primitives: build-statics
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives"
+
+## Cypress stuff used in local dev
+
+### Opens an interactive UI for specifying which tests to run/re-run
+cypress-open:
+	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+	cypress open
+
+### Runs tests for pages (assumes the app is running in another terminal)
+cypress-run-page:
+	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js"
+
+### Runs tests for primitive components (assumes the app is running in another terminal)
+cypress-run-primitives:
+	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
+	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js"
+
+# Deploy
+
+prepublish:
+	babel packages/tc-ui/src -D --out-dir packages/tc-ui/dist
+	sed s/"src\/"/"dist\/"/ packages/tc-ui/package.json > tmp && mv tmp packages/tc-ui/package.json
+
+monorepo-publish: prepublish
+	npx athloi version --concurrency 10 $(CIRCLE_TAG)
+	npx athloi publish --concurrency 10 -- --access public

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ install: unprepublish
 ## Builds browser files for tc-ui (in watch mode when local)
 build-statics:
 	@if [ -z $(CI) ]; \
-		then $(info Webpack bundling modules ...) ./node_modules/.bin/webpack --mode=development --watch; \
+		then $(info Webpack bundling modules ...) webpack --mode=development --watch; \
 		else $(info Webpack bundling modules ...) webpack --mode=production; \
 	fi
 


### PR DESCRIPTION
## Why?

Tasks were poorly organised. Also webpack had stopped running in watch mode locally because of some changes made to support cypress

## What?
- Reorders and groups into Install, Build & Test sections
- Documents what the various cypress tasks are used for
- Defines a new `run-app-biz-ops` task so we can use `concurrently` to run that task in parallel with webpack in watch mode
- _Hopefully_ doesn't break anything