### PR TITLE
Create index can identify

### DIFF
--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -69,6 +69,7 @@ properties:
     type: Url
     description: Url description.
     label: Url label
+    canIdentify: true
   children:
     relationship: HAS_CHILD
     type: ChildType

--- a/packages/tc-api-db-manager/__tests__/db-manager.spec.js
+++ b/packages/tc-api-db-manager/__tests__/db-manager.spec.js
@@ -60,6 +60,7 @@ describe('creating db constraints and indexes', () => {
 		expect(dbRun).toHaveBeenCalledWith(
 			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
 		);
+		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()
 	it.skip("creates an existence constraint if it doesn't exist", async () => {
@@ -86,8 +87,9 @@ describe('creating db constraints and indexes', () => {
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
+			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
 		);
+		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
 
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()
@@ -101,8 +103,9 @@ describe('creating db constraints and indexes', () => {
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)',
+			'CREATE CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)',
 		);
+		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
 
 	it('creates a index for canIdentify property if it doesnt exist', async () => {
@@ -115,6 +118,7 @@ describe('creating db constraints and indexes', () => {
 		]);
 		await initConstraints();
 		expect(dbRun).toHaveBeenCalledWith('CREATE INDEX ON :Dog(tail)');
+		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
 
 	it('doesnt create an index for for canIdentify property if it does exist', async () => {
@@ -127,6 +131,8 @@ describe('creating db constraints and indexes', () => {
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith('CREATE INDEX ON :Dog(nose)');
+
+		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
 
 	it('doesnt create an index if a uniqueness constraint will be created', async () => {
@@ -141,6 +147,10 @@ describe('creating db constraints and indexes', () => {
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith('CREATE INDEX ON :Dog(tail)');
+		expect(dbRun).toHaveBeenCalledWith(
+			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
+		);
+		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
 
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()

--- a/packages/tc-api-db-manager/__tests__/db-manager.spec.js
+++ b/packages/tc-api-db-manager/__tests__/db-manager.spec.js
@@ -121,7 +121,7 @@ describe('creating db constraints and indexes', () => {
 		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
 
-	it('doesnt create an index for for canIdentify property if it does exist', async () => {
+	it('doesnt create an index for a canIdentify property if it does exist', async () => {
 		mockConstraints({
 			stub: dbRun,
 			indexes: ['CREATE INDEX ON :Dog(nose)'],

--- a/packages/tc-api-db-manager/__tests__/db-manager.spec.js
+++ b/packages/tc-api-db-manager/__tests__/db-manager.spec.js
@@ -4,7 +4,12 @@ schema.init();
 const { initConstraints } = require('..');
 const { driver } = require('../db-connection');
 
-const mockConstraints = (stub, constraints, writeResponse) => {
+const mockConstraints = ({
+	stub,
+	constraints = [],
+	indexes = [],
+	writeResponse,
+} = {}) => {
 	stub.mockImplementation(query => {
 		if (query === 'CALL db.constraints') {
 			return Promise.resolve({
@@ -13,6 +18,15 @@ const mockConstraints = (stub, constraints, writeResponse) => {
 				})),
 			});
 		}
+
+		if (query === 'CALL db.indexes') {
+			return Promise.resolve({
+				records: indexes.map(val => ({
+					get: () => val,
+				})),
+			});
+		}
+
 		return (
 			writeResponse ||
 			Promise.resolve({
@@ -22,7 +36,7 @@ const mockConstraints = (stub, constraints, writeResponse) => {
 	});
 };
 
-describe('creating db constraints', () => {
+describe('creating db constraints and indexes', () => {
 	let dbRun;
 	beforeEach(() => {
 		jest.spyOn(schema, 'getTypes');
@@ -35,9 +49,10 @@ describe('creating db constraints', () => {
 	afterEach(() => jest.restoreAllMocks());
 
 	it("creates a uniqueness constraint if it doesn't exist", async () => {
-		mockConstraints(dbRun, [
-			'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
-		]);
+		mockConstraints({
+			stub: dbRun,
+			constraints: ['CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { unique: true } } },
 		]);
@@ -48,7 +63,10 @@ describe('creating db constraints', () => {
 	});
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()
 	it.skip("creates an existence constraint if it doesn't exist", async () => {
-		mockConstraints(dbRun, ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)']);
+		mockConstraints({
+			stub: dbRun,
+			constraints: ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { required: true } } },
 		]);
@@ -59,32 +77,39 @@ describe('creating db constraints', () => {
 	});
 
 	it("doesn't create a uniqueness constraint if it does exist", async () => {
-		mockConstraints(dbRun, [
-			'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
-		]);
+		mockConstraints({
+			stub: dbRun,
+			constraints: ['CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { unique: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
+			'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
 		);
 	});
 
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()
 	it.skip("doesn't create an existence constraint if it does exist", async () => {
-		mockConstraints(dbRun, ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)']);
+		mockConstraints({
+			stub: dbRun,
+			constraints: ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { required: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT exists(s.tail)',
+			'CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)',
 		);
 	});
 
 	it('creates a index for canIdentify property if it doesnt exist', async () => {
-		mockConstraints(dbRun, ['CREATE INDEX ON :Dog(nose)']);
+		mockConstraints({
+			stub: dbRun,
+			indexes: ['CREATE INDEX ON :Dog(nose)'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { canIdentify: true } } },
 		]);
@@ -93,16 +118,21 @@ describe('creating db constraints', () => {
 	});
 
 	it('doesnt create an index for for canIdentify property if it does exist', async () => {
-		mockConstraints(dbRun, ['CREATE INDEX ON :Dog(nose)']);
+		mockConstraints({
+			stub: dbRun,
+			indexes: ['CREATE INDEX ON :Dog(nose)'],
+		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { canIdentify: true } } },
 		]);
 		await initConstraints();
-		expect(dbRun).not.toHaveBeenCalledWith('CREATE INDEX ON :Dog(tail)');
+		expect(dbRun).not.toHaveBeenCalledWith('CREATE INDEX ON :Dog(nose)');
 	});
 
 	it('doesnt create an index if a uniqueness constraint will be created', async () => {
-		mockConstraints(dbRun, ['CREATE INDEX ON :Dog(nose)']);
+		mockConstraints({
+			stub: dbRun,
+		});
 		schema.getTypes.mockReturnValue([
 			{
 				name: 'Dog',
@@ -115,11 +145,14 @@ describe('creating db constraints', () => {
 
 	// ignore this test until we upgrade to enterprise adiition - community edition doesn't have exists()
 	it.skip('handles a mixture of creates, ignores and removes', async () => {
-		mockConstraints(dbRun, [
-			'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
-			'CONSTRAINT ON (s:Dog) ASSERT exists(s.tail)',
-			'CONSTRAINT ON (s:Cat) ASSERT exists(s.tail)',
-		]);
+		mockConstraints({
+			stub: dbRun,
+			constraints: [
+				'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
+				'CONSTRAINT ON (s:Dog) ASSERT exists(s.tail)',
+				'CONSTRAINT ON (s:Cat) ASSERT exists(s.tail)',
+			],
+		});
 		schema.getTypes.mockReturnValue([
 			{
 				name: 'Dog',
@@ -141,11 +174,10 @@ describe('creating db constraints', () => {
 
 	it('handles failure gracefully', async () => {
 		schema.getTypes.mockReturnValue([]);
-		mockConstraints(
-			dbRun,
-			[],
-			Promise.reject(new Error('db call has failed')),
-		);
+		mockConstraints({
+			stub: dbRun,
+			writeResponse: Promise.reject(new Error('db call has failed')),
+		});
 		// this should not throw
 		await initConstraints();
 	});

--- a/packages/tc-api-db-manager/__tests__/db-manager.spec.js
+++ b/packages/tc-api-db-manager/__tests__/db-manager.spec.js
@@ -51,14 +51,16 @@ describe('creating db constraints and indexes', () => {
 	it("creates a uniqueness constraint if it doesn't exist", async () => {
 		mockConstraints({
 			stub: dbRun,
-			constraints: ['CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE'],
+			constraints: [
+				'CONSTRAINT ON ( dog:Dog ) ASSERT dog.nose IS UNIQUE',
+			],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { unique: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT dog.tail IS UNIQUE',
 		);
 		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
@@ -66,28 +68,30 @@ describe('creating db constraints and indexes', () => {
 	it.skip("creates an existence constraint if it doesn't exist", async () => {
 		mockConstraints({
 			stub: dbRun,
-			constraints: ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)'],
+			constraints: ['CONSTRAINT ON ( dog:Dog ) ASSERT exists(s.nose)'],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { required: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT exists(s.tail)',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT exists(s.tail)',
 		);
 	});
 
 	it("doesn't create a uniqueness constraint if it does exist", async () => {
 		mockConstraints({
 			stub: dbRun,
-			constraints: ['CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE'],
+			constraints: [
+				'CONSTRAINT ON ( dog:Dog ) ASSERT dog.nose IS UNIQUE',
+			],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { unique: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT dog.nose IS UNIQUE',
 		);
 		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
@@ -96,22 +100,22 @@ describe('creating db constraints and indexes', () => {
 	it.skip("doesn't create an existence constraint if it does exist", async () => {
 		mockConstraints({
 			stub: dbRun,
-			constraints: ['CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)'],
+			constraints: ['CONSTRAINT ON ( dog:Dog ) ASSERT exists(dog.nose)'],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { required: true } } },
 		]);
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT exists(s.nose)',
 		);
 		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
 
-	it('creates a index for canIdentify property if it doesnt exist', async () => {
+	it('creates a index for canIdentify property if it doesnt exist already', async () => {
 		mockConstraints({
 			stub: dbRun,
-			indexes: ['CREATE INDEX ON :Dog(nose)'],
+			indexes: ['INDEX ON :Dog(nose)'],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { tail: { canIdentify: true } } },
@@ -124,7 +128,7 @@ describe('creating db constraints and indexes', () => {
 	it('doesnt create an index for a canIdentify property if it does exist', async () => {
 		mockConstraints({
 			stub: dbRun,
-			indexes: ['CREATE INDEX ON :Dog(nose)'],
+			indexes: ['INDEX ON :Dog(nose)'],
 		});
 		schema.getTypes.mockReturnValue([
 			{ name: 'Dog', properties: { nose: { canIdentify: true } } },
@@ -135,7 +139,7 @@ describe('creating db constraints and indexes', () => {
 		expect(dbRun).toHaveBeenCalledTimes(4);
 	});
 
-	it('doesnt create an index if a uniqueness constraint will be created', async () => {
+	it('does not create an index for fields with an existing unique constraint', async () => {
 		mockConstraints({
 			stub: dbRun,
 		});
@@ -148,7 +152,7 @@ describe('creating db constraints and indexes', () => {
 		await initConstraints();
 		expect(dbRun).not.toHaveBeenCalledWith('CREATE INDEX ON :Dog(tail)');
 		expect(dbRun).toHaveBeenCalledWith(
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT dog.tail IS UNIQUE',
 		);
 		expect(dbRun).toHaveBeenCalledTimes(5);
 	});
@@ -158,9 +162,9 @@ describe('creating db constraints and indexes', () => {
 		mockConstraints({
 			stub: dbRun,
 			constraints: [
-				'CONSTRAINT ON (s:Dog) ASSERT s.nose IS UNIQUE',
-				'CONSTRAINT ON (s:Dog) ASSERT exists(s.tail)',
-				'CONSTRAINT ON (s:Cat) ASSERT exists(s.tail)',
+				'CONSTRAINT ON ( dog:Dog ) ASSERT s.nose IS UNIQUE',
+				'CONSTRAINT ON ( dog:Dog ) ASSERT exists(dog.tail)',
+				'CONSTRAINT ON ( cat:Cat ) ASSERT exists(cat.tail)',
 			],
 		});
 		schema.getTypes.mockReturnValue([
@@ -176,9 +180,9 @@ describe('creating db constraints and indexes', () => {
 		await initConstraints();
 
 		[
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT s.tail IS UNIQUE',
-			'CREATE CONSTRAINT ON (s:Dog) ASSERT exists(s.nose)',
-			'CREATE CONSTRAINT ON (s:Cat) ASSERT exists(s.whiskers)',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT s.tail IS UNIQUE',
+			'CREATE CONSTRAINT ON ( dog:Dog ) ASSERT exists(dog.nose)',
+			'CREATE CONSTRAINT ON ( cat:Cat ) ASSERT exists(cat.whiskers)',
 		].forEach(query => expect(dbRun).toHaveBeenCalledWith(query));
 	});
 

--- a/packages/tc-api-db-manager/index.js
+++ b/packages/tc-api-db-manager/index.js
@@ -33,14 +33,21 @@ const initConstraints = async () => {
 				...schema.getTypes().map(({ name: typeName, properties }) => {
 					return [].concat(
 						...Object.entries(properties).map(
-							([propName, { unique }]) => {
-								return [
-									unique &&
+							([propName, { unique, canIdentify }]) => {
+								if (unique) {
+									return [
 										`CONSTRAINT ON (s:${typeName}) ASSERT s.${propName} IS UNIQUE`,
+									];
 									// skip the setting of enterprise version specific constraints until we use the enterprise version
-									// required &&
-									// 	`CONSTRAINT ON (s:${typeName}) ASSERT exists(s.${propName})`
-								];
+									// 	// required &&
+									// 	// 	`CONSTRAINT ON (s:${typeName}) ASSERT exists(s.${propName})`
+									// ];
+								}
+								if (canIdentify) {
+									return [
+										`INDEX ON :${typeName}(${propName})`,
+									];
+								}
 							},
 						),
 					);


### PR DESCRIPTION
## Why?

To resolve [issue](https://github.com/Financial-Times/treecreeper/issues/206)

#### Problem 
When running CALL db.indexes(); in neo4j only 23 are retrieved, but there should be many more, as stipulated by the use of canIdentify on properties in the schema.

In tc-api-db-manager only properties marked with unique are indexed... this should most likely be updated to go by canIdentify 

-   What's the main motivation of this work? bug fix

## What?

I added a condition for to check for canIdentify property. If this is present when unique is false the code marks this field for index creation. I have also updated the code to retrieve current indexes, if the index already exists nothing further will happen, if the index is not present a new index will be created for the field with canIdentify. 

When implementing I noticed that the tests checking that existing constraints were not created again did not actually check that behaviour so I have updated these also. 

I have also added on check for amount of calls expected to `db.run` whilst this is not all that clear on first glance, it should help highlight incorrect passes when uses the .not. expectation, as if there is a typo / error in `.not` expectation the test would still pass.  

_Would appreciate a second pair of eyes on the test_  to confirm this makes sense with intended behaviour. 