### PR TITLE
Include a check for multiple descriptions which be corrupted by markdown

### DIFF
--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -23,6 +23,20 @@ properties:
     description: Word description.
     label: Word label
     useInSummary: true
+  hasLongDescription:
+    type: Word
+    description: This is a very long description of a schema item to prove that more than 80 characters can be used if a single line is used.
+    label: Word label
+    useInSummary: true
+  hasMutliLineDescription:
+    type: Word
+    description: |
+      These are many lines of decription each of which is of length 80 to prove length
+      These are many lines of decription each of which is of length 80 to prove length
+      These are many lines of decription each of which is of length 80 to prove length
+      These are many lines of decription each of which is of length 80 to prove sizes.
+    label: Word label
+    useInSummary: true
   # someStringList:
   #   type: Word
   #   hasMany: true
@@ -145,3 +159,4 @@ properties:
     type: AnotherEnum
     description: An enum that has something next to it.
     label: Multiple choice next to another thing
+

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -117,6 +117,11 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 				expect(typeof config.description).toBe('string');
 				expect(/[.?]$/.test(config.description.trim())).toBe(true);
 			});
+			it('has valid markdown formatted description', () => {
+				if (config.description.indexOf('\n') > -1) {
+					config.description.split('\n').map(oneLine => expect(oneLine.length).toBeLessThanOrEqual(80));
+				}
+			});
 			it('has valid type', () => {
 				expect(config.type).toBeDefined();
 				expect(config.type).toMatch(arrayToRegExp(validPropTypes));

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -118,7 +118,7 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 				expect(/[.?]$/.test(config.description.trim())).toBe(true);
 			});
 			it('has valid markdown formatted description', () => {
-				if (config.description.indexOf('\n') > -1) {
+				if (config.description.replace(/\n$/, '').indexOf('\n') > -1) {
 					config.description
 						.split('\n')
 						.map(oneLine =>

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -119,7 +119,11 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 			});
 			it('has valid markdown formatted description', () => {
 				if (config.description.indexOf('\n') > -1) {
-					config.description.split('\n').map(oneLine => expect(oneLine.length).toBeLessThanOrEqual(80));
+					config.description
+						.split('\n')
+						.map(oneLine =>
+							expect(oneLine.length).toBeLessThanOrEqual(80),
+						);
 				}
 			});
 			it('has valid type', () => {


### PR DESCRIPTION
## Why?

-   Starts to fix: https://github.com/Financial-Times/treecreeper/issues/245
-   Multi-line descriptions are corrupted by markdown formatting due to their explicit new lines.

## What?

-   Check for single and multi-line descriptions
-   Single line descriptions can be of any length since markdown will generate html which wraps the text nicely
-   Multi-line descriptions can only be 80 characters per line since any more will trigger the inclusion of an extra new line (over and above the one present at the end of the line) during wrapping.
- The aim is to avoid wrapping lines within multi-line descriptions


### Anything in particular you'd like to highlight to reviewers?

This finds the descriptions that would cause the issue but doesn't fix them.

The first time the current `biz-ops-schema` is run against this version of the `tc-schema-validator` it will fail with the list of descriptions which need to be reformatted,
