### PR TITLE
stop sending update events when noop deleted of relationship properties occur

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^5.0.0",
     "css-loader": "^3.2.1",
     "cypress": "^3.8.2",
-    "fetch-mock": "^9.6.0-alpha.2",
+    "fetch-mock": "^9.9.0",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^24.8.0",
     "jest-junit": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "concurrently": "^5.0.0",
     "css-loader": "^3.2.1",
     "cypress": "^3.8.2",
-    "fetch-mock": "^8.0.0",
+    "fetch-mock": "^9.6.0-alpha.2",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^24.8.0",
     "jest-junit": "^7.0.0",

--- a/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
+++ b/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
@@ -226,7 +226,7 @@ describe('Rest events module integration', () => {
 			expectUpdateEvent(childType, childCode, ['isChildOf']);
 		});
 
-		it('should not send extra UPDATE events when making noop property removal edit to rich relationship', async () => {
+		it('should not send extra UPDATE events when removing rich relationship property that was already non-existent', async () => {
 			const [main, child] = await Promise.all([
 				createMainNode(),
 				createNode(childType, { code: childCode }),

--- a/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
+++ b/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
@@ -100,7 +100,6 @@ describe('Rest events module integration', () => {
 			expect(emitSpy).toHaveBeenCalledTimes(2);
 			expectCreateEvent(mainType, mainCode, [
 				'children',
-
 				'code',
 				'deprecatedChildren',
 				'someString',
@@ -225,6 +224,31 @@ describe('Rest events module integration', () => {
 				'someString',
 			]);
 			expectUpdateEvent(childType, childCode, ['isChildOf']);
+		});
+
+		it('should not send extra UPDATE events when making noop property removal edit to rich relationship', async () => {
+			const [main, child] = await Promise.all([
+				createMainNode(),
+				createNode(childType, { code: childCode }),
+			]);
+			await connectNodes(main, 'HAS_CURIOUS_CHILD', child);
+
+			const { status } = await patchHandler()(
+				getInput(
+					{
+						someString: 'some string',
+						curiousChild: {
+							code: childCode,
+							someString: null,
+						},
+					},
+					{ relationshipAction: 'replace', upsert: true },
+				),
+			);
+
+			expect(status).toBe(200);
+			expect(emitSpy).toHaveBeenCalledTimes(1);
+			expectUpdateEvent(mainType, mainCode, ['someString']);
 		});
 	});
 

--- a/packages/tc-api-rest-handlers/lib/relationships/input.js
+++ b/packages/tc-api-rest-handlers/lib/relationships/input.js
@@ -13,9 +13,13 @@ const arrDiff = (arr1, arr2) =>
 const relationshipPropsDiff = (newRelationship, existingRelationship) => {
 	const diffs = {};
 	Object.keys(newRelationship).forEach(prop => {
-		if (newRelationship[prop] !== existingRelationship[prop]) {
-			diffs[prop] = newRelationship[prop];
+		if (newRelationship[prop] === existingRelationship[prop]) {
+			return;
 		}
+		if (newRelationship[prop] === null && !(prop in existingRelationship)) {
+			return;
+		}
+		diffs[prop] = newRelationship[prop];
 	});
 	return diffs;
 };

--- a/packages/tc-api-rest-handlers/patch.js
+++ b/packages/tc-api-rest-handlers/patch.js
@@ -81,6 +81,7 @@ const patchHandler = ({ documentStore } = {}) => {
 					type,
 					richRelationshipsFlag: richRelationships,
 				});
+
 				event.changedRelationships = queryContext.changedRelationships;
 				event.removedRelationships = queryContext.removedRelationships;
 				event.neo4jResult = neo4jResult;


### PR DESCRIPTION
## Why?
Since adding rich relationships to the model edits made in Biz Ops admin to systems have been causing excess update events in the kinesis stream.

After digging around quite a bit I discovered that the form was posting e.g `dependencies: [{code: 'abc', 'resiliencePatterns': null}]` when no relationship properties were added. The API was unable to tell that writing `null` to a previously undefined property had no effect, and instead thought this was a substantive change, causing an unnecessary write to the database and several change events in the kinesis stream.
## What?
- adds a test for this edge case
- explicitly handles the case where the existing property is not defined and a null value is sent, and treats this as 'no difference'