### PR TITLE
easier to get going with graphql explorer

### DIFF
--- a/demo/api.js
+++ b/demo/api.js
@@ -21,11 +21,16 @@ app.use(
 	}),
 );
 
+// removes a little bit of hassle from manually testing the api
+app.use((req, res, next) => {
+	req.headers['client-id'] = 'treecreeper-demo';
+	next()
+})
+
 getApp({
 	treecreeperPath: '/api',
 	app,
 	graphqlMethods: ['post', 'get'],
-
 	documentStore: process.env.WITH_DOCSTORE
 		? createStore(`biz-ops-documents.${process.env.AWS_ACCOUNT_ID}`)
 		: null,
@@ -45,7 +50,11 @@ const {
 } = require('./cms');
 
 const parseBody = bodyParser.urlencoded({ limit: '8mb', extended: true });
-app.get('/lalala', anotherController);
+app.get('/', (req, res) => {
+	res.send(`<html><head></head><body>
+<a href="/graphiql">GraphQL explorer.</a>
+</body></html>`)
+});
 app.get('/:type/:code/edit', editController);
 app.post('/:type/:code/edit', parseBody, editController);
 app.get('/:type/create', editController);

--- a/demo/api.js
+++ b/demo/api.js
@@ -23,9 +23,11 @@ app.use(
 
 // removes a little bit of hassle from manually testing the api
 app.use((req, res, next) => {
-	req.headers['client-id'] = 'treecreeper-demo';
-	next()
-})
+	if (/\/graphiql$/.test(req.headers.referer)) {
+		req.headers['client-id'] = 'treecreeper-demo';
+	}
+	next();
+});
 
 getApp({
 	treecreeperPath: '/api',
@@ -42,18 +44,13 @@ getApp({
 });
 
 require('@babel/register'); // eslint-disable-line  import/no-extraneous-dependencies
-const {
-	editController,
-	viewController,
-	deleteController,
-	anotherController,
-} = require('./cms');
+const { editController, viewController, deleteController } = require('./cms');
 
 const parseBody = bodyParser.urlencoded({ limit: '8mb', extended: true });
 app.get('/', (req, res) => {
 	res.send(`<html><head></head><body>
 <a href="/graphiql">GraphQL explorer.</a>
-</body></html>`)
+</body></html>`);
 });
 app.get('/:type/:code/edit', editController);
 app.post('/:type/:code/edit', parseBody, editController);

--- a/demo/cms/index.js
+++ b/demo/cms/index.js
@@ -1,4 +1,3 @@
-const React = require('react');
 const logger = require('@financial-times/lambda-logger');
 const { getCMS } = require('@financial-times/tc-ui');
 

--- a/demo/cms/index.jsx
+++ b/demo/cms/index.jsx
@@ -48,9 +48,4 @@ module.exports = {
 	viewController: wrapCmsHandler(viewHandler),
 	editController: wrapCmsHandler(editHandler),
 	deleteController: wrapCmsHandler(deleteHandler),
-	anotherController: wrapCmsHandler(
-		handleError(() =>
-			renderPage(({ str }) => <div>{str}</div>, { str: 'lalalala' }),
-		),
-	),
 };


### PR DESCRIPTION
## Why?

When getting Leanne and (IIRC) Kirsten onboarded I think they were both hit by problems connecting to the graphql explorer with no clear feedback on how to get unblocked.

## What?

- index page of the demo app links to the graphql explorer
- middleware always adds client id to api request made by the graphql explorer, so that the api does not error
- removed an old controller that was added to test some stuff out a while back but I don't think is useful any more