### PR TITLE
Fix #190

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ cypress-verify:
 
 ### Runs tests for pages
 cypress-page: build-statics
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page" --video false
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page"
 
 ### Runs tests for primitive components
 cypress-primitives: build-statics
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives" --video false
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives"
 
 ## Cypress stuff used in local dev
 

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ cypress-verify:
 
 ### Runs tests for pages
 cypress-page: build-statics
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page"
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-page" --video false
 
 ### Runs tests for primitive components
 cypress-primitives: build-statics
-	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives"
+	start-server-and-test "make run-app" http-get://localhost:8888/MainType/create "make cypress-run-primitives" --video false
 
 ## Cypress stuff used in local dev
 
@@ -132,12 +132,12 @@ cypress-open:
 ### Runs tests for pages (assumes the app is running in another terminal)
 cypress-run-page:
 	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js"
+	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js" --video false
 
 ### Runs tests for primitive components (assumes the app is running in another terminal)
 cypress-run-primitives:
 	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js"
+	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js" --video false
 
 # Deploy
 

--- a/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
@@ -209,6 +209,7 @@ const queryBuilder = (method, input, body = {}) => {
 		queryParts.unshift(getBaseQuery(type, method, willUpdateMeta));
 		queryParts.push(getNeo4jRecordCypherQuery());
 		const neo4jQuery = queryParts.join('\n');
+		console.log({parameters})
 		const neo4jResult = await executeQuery(neo4jQuery, parameters);
 
 		return {

--- a/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
@@ -209,7 +209,6 @@ const queryBuilder = (method, input, body = {}) => {
 		queryParts.unshift(getBaseQuery(type, method, willUpdateMeta));
 		queryParts.push(getNeo4jRecordCypherQuery());
 		const neo4jQuery = queryParts.join('\n');
-		console.log({parameters})
 		const neo4jResult = await executeQuery(neo4jQuery, parameters);
 
 		return {

--- a/packages/tc-api-rest-handlers/patch.js
+++ b/packages/tc-api-rest-handlers/patch.js
@@ -26,7 +26,6 @@ const patchHandler = ({ documentStore } = {}) => {
 			query: { relationshipAction, richRelationships } = {},
 			metadata = {},
 		} = validateInput(input);
-		console.log({originalBody})
 		if (containsRelationshipData(type, originalBody)) {
 			validateRelationshipAction(relationshipAction);
 			validateRelationshipInput(originalBody);

--- a/packages/tc-api-rest-handlers/patch.js
+++ b/packages/tc-api-rest-handlers/patch.js
@@ -26,7 +26,7 @@ const patchHandler = ({ documentStore } = {}) => {
 			query: { relationshipAction, richRelationships } = {},
 			metadata = {},
 		} = validateInput(input);
-
+		console.log({originalBody})
 		if (containsRelationshipData(type, originalBody)) {
 			validateRelationshipAction(relationshipAction);
 			validateRelationshipInput(originalBody);

--- a/packages/tc-ui/src/pages/view/handler.js
+++ b/packages/tc-ui/src/pages/view/handler.js
@@ -12,7 +12,6 @@ const getViewHandler = ({
 		const { type, code, error } = event;
 		const apiClient = getApiClient(event);
 		const data = await apiClient.read(type, code);
-
 		return renderPage({
 			template,
 			data: {

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -18,6 +18,20 @@ describe('End-to-end - record Temporal type', () => {
 		});
 	});
 
+	it('can record time', () => {
+		cy.get('input[name=someTime]')
+			.click()
+			.then(input => {
+				input[0].dispatchEvent(new Event('input', { bubbles: true }));
+				input.val('12:15:30Z');
+			})
+			.click();
+		save();
+
+		cy.get('#code').should('have.text', code);
+		cy.get('#someDate').should('have.text', '12:15:30 PM');
+	});
+
 	it('can record date', () => {
 		cy.get('input[name=someDate]')
 			.click()

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -23,17 +23,17 @@ describe('End-to-end - record Temporal type', () => {
 			.click()
 			.then(input => {
 				input[0].dispatchEvent(new Event('input', { bubbles: true }));
-				input.val('12:15:30Z');
+				input.val('12:15:30');
 			})
 			.click();
 		save();
 
 		cy.get('#code').should('have.text', code);
-		cy.get('#someDate').should('have.text', '12:15:30 PM');
+		cy.get('#someTime').should('have.text', '12:15:30 PM');
 		cy.get('[data-button-type="edit"]').click({
 			force: true,
 		});
-		cy.get('input[name=someTime]').should('have.value', '12:15:30Z')
+		cy.get('input[name=someTime]').should('have.value', '12:15:30')
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someTime').should('have.text', '12:15:30 PM');
@@ -78,7 +78,7 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('[data-button-type="edit"]').click({
 			force: true,
 		});
-		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T01:00:00')
+		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T13:00:00.000')
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDatetime').should('have.text', '15 January 2020, 1:00:00 PM');

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -33,7 +33,7 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('[data-button-type="edit"]').click({
 			force: true,
 		});
-		cy.get('input[name=someTime]').should('have.value', '12:15:30')
+		cy.get('input[name=someTime]').should('have.value', '12:15:30');
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someTime').should('have.text', '12:15:30 PM');
@@ -54,7 +54,7 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('[data-button-type="edit"]').click({
 			force: true,
 		});
-		cy.get('input[name=someDate]').should('have.value', '2020-01-15')
+		cy.get('input[name=someDate]').should('have.value', '2020-01-15');
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDate').should('have.text', '15 January 2020');
@@ -78,9 +78,15 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('[data-button-type="edit"]').click({
 			force: true,
 		});
-		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T13:00:00.000')
+		cy.get('input[name=someDatetime]').should(
+			'have.value',
+			'2020-01-15T13:00:00.000',
+		);
 		save();
 		cy.get('#code').should('have.text', code);
-		cy.get('#someDatetime').should('have.text', '15 January 2020, 1:00:00 PM');
+		cy.get('#someDatetime').should(
+			'have.text',
+			'15 January 2020, 1:00:00 PM',
+		);
 	});
 });

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -30,6 +30,13 @@ describe('End-to-end - record Temporal type', () => {
 
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDate').should('have.text', '12:15:30 PM');
+		cy.get('[data-button-type="edit"]').click({
+			force: true,
+		});
+		cy.get('input[name=someTime]').should('have.value', '12:15:30Z')
+		save();
+		cy.get('#code').should('have.text', code);
+		cy.get('#someTime').should('have.text', '12:15:30 PM');
 	});
 
 	it('can record date', () => {
@@ -42,6 +49,13 @@ describe('End-to-end - record Temporal type', () => {
 			.click();
 		save();
 
+		cy.get('#code').should('have.text', code);
+		cy.get('#someDate').should('have.text', '15 January 2020');
+		cy.get('[data-button-type="edit"]').click({
+			force: true,
+		});
+		cy.get('input[name=someDate]').should('have.value', '2020-01-15')
+		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDate').should('have.text', '15 January 2020');
 	});
@@ -61,5 +75,12 @@ describe('End-to-end - record Temporal type', () => {
 			'have.text',
 			'15 January 2020, 1:00:00 PM',
 		);
+		cy.get('[data-button-type="edit"]').click({
+			force: true,
+		});
+		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T01:00:00')
+		save();
+		cy.get('#code').should('have.text', code);
+		cy.get('#someDatetime').should('have.text', '15 January 2020, 1:00:00 PM');
 	});
 });

--- a/packages/tc-ui/src/primitives/temporal/server.jsx
+++ b/packages/tc-ui/src/primitives/temporal/server.jsx
@@ -17,7 +17,7 @@ const formatTemporal = (value, type) => {
 	}
 
 	if (type === 'Time') {
-		return formatValue(`2020-01-15T${value}`, 'h:mm:ss a')
+		return formatValue(`2020-01-15T${value}`, 'h:mm:ss a');
 	}
 };
 
@@ -31,7 +31,7 @@ const convertValueForHTMLInput = (wrappedValue, type) => {
 	// the input doesn't error
 	// Should probably store the timestamps without any timezone info for
 	// consistency, but that's a bug to fix in future
-	if (type === 'Time') return value.split(/Z|\+|\-/)[0];
+	if (type === 'Time') return value.split(/Z|\+|-/)[0];
 	const date = new Date(value).toISOString();
 	return type === 'DateTime' ? date.split('Z')[0] : date.split('T')[0];
 };
@@ -62,7 +62,9 @@ const EditTemporal = ({
 			<input
 				name={name}
 				id={`id-${propertyName}`}
-				type={type === 'DateTime' ? 'datetime-local' : type.toLowerCase()}
+				type={
+					type === 'DateTime' ? 'datetime-local' : type.toLowerCase()
+				}
 				step={type === 'Time' ? 1 : null}
 				value={convertValueForHTMLInput(value, type)}
 				required={required ? 'required' : null}

--- a/packages/tc-ui/src/primitives/temporal/server.jsx
+++ b/packages/tc-ui/src/primitives/temporal/server.jsx
@@ -10,10 +10,7 @@ const formatValue = (value, formatString) =>
 // TODO this probably errors - need to write comprehensive tests
 // If date and time are given, time can be formatted but if not,
 // time will be returned as it was inputted. This allows for manual time inputs
-const formatTime = timeInput =>
-	format(timeInput, 'h:mm:ss a') !== 'Invalid Date'
-		? format(timeInput, 'h:mm:ss a')
-		: timeInput;
+const formatTime = timeInput => format(parseISO(`2020-01-15T${timeInput}`), 'h:mm:ss a');
 
 const formatDateTime = (value, type) => {
 	if (type === 'DateTime') {


### PR DESCRIPTION
## Why?

The UI did not cope with fields of type Time #190 

## What?
- added more hacks to the value parsing. Ultimately the behaviour around how to handle timezones is very hacky, but without a real case it's hard to know what behaviour to implement. For now the focus is on 'just don't error' so that times that don't use time zones do at least work
- cypress tests for time, but also added tests for datetime and date to make sure values that are saved can then be redisplayed successfully in the edit component and resaved i.e user input -> db  -> parse back to form data -> save 