### PR TITLE
Multi graphql

### DIFF
--- a/demo/api.js
+++ b/demo/api.js
@@ -23,7 +23,7 @@ const addBetaGraphqlApi = ({ app: theApp, apiPath, schemaBaseUrl }) => {
 	listenForSchemaChanges();
 
 	theApp.post(apiPath, graphqlHandler);
-	return {ready: () => schema.ready() };
+	return { ready: () => schema.ready() };
 };
 
 const PORT = process.env.PORT || 8888;
@@ -57,7 +57,7 @@ const tcApiPromise = getApp({
 		: null,
 });
 
-const { ready: betGraphqlReady } = addBetaGraphqlApi({
+const { ready: betaGraphqlReady } = addBetaGraphqlApi({
 	app,
 	apiPath: '/api/beta-graphql',
 	schemaBaseUrl:
@@ -80,7 +80,7 @@ app.post('/:type/create', parseBody, editController);
 app.post('/:type/:code/delete', deleteController);
 app.get('/:type/:code', viewController);
 
-Promise.all([tcApiPromise, betGraphqlReady()]).then(() => {
+Promise.all([tcApiPromise, betaGraphqlReady()]).then(() => {
 	app.listen(PORT, () => {
 		// eslint-disable-next-line no-console
 		console.log(`Listening on ${PORT}`);

--- a/demo/api.js
+++ b/demo/api.js
@@ -23,7 +23,7 @@ const addBetaGraphqlApi = ({ app: theApp, apiPath, schemaBaseUrl }) => {
 	listenForSchemaChanges();
 
 	theApp.post(apiPath, graphqlHandler);
-	return { schema };
+	return {ready: () => schema.ready() };
 };
 
 const PORT = process.env.PORT || 8888;
@@ -57,7 +57,7 @@ const tcApiPromise = getApp({
 		: null,
 });
 
-const { schema: secondarySchema } = addBetaGraphqlApi({
+const { ready: betGraphqlReady } = addBetaGraphqlApi({
 	app,
 	apiPath: '/api/beta-graphql',
 	schemaBaseUrl:
@@ -80,7 +80,7 @@ app.post('/:type/create', parseBody, editController);
 app.post('/:type/:code/delete', deleteController);
 app.get('/:type/:code', viewController);
 
-Promise.all([tcApiPromise, secondarySchema.ready()]).then(() => {
+Promise.all([tcApiPromise, betGraphqlReady()]).then(() => {
 	app.listen(PORT, () => {
 		// eslint-disable-next-line no-console
 		console.log(`Listening on ${PORT}`);

--- a/packages/tc-api-graphql/README.md
+++ b/packages/tc-api-graphql/README.md
@@ -73,6 +73,10 @@ An [optional] object value for adding extra/custom resolvers
 
 An [optional] array of type names to exclude from neo4j-graphql-js augmentation. This should list all types which get data from sources other than the neo4j
 
+#### `schemaInstance` [optional]
+
+An instance of `tc-schema-sdk`. This can be used to host multiple graphql APIs running off multiple different schemas within the same application.
+
 ## Example
 
 ```js

--- a/packages/tc-api-graphql/__tests__/graphql.spec.js
+++ b/packages/tc-api-graphql/__tests__/graphql.spec.js
@@ -358,27 +358,25 @@ describe('graphql', () => {
 		});
 
 		describe('custom schema', () => {
-
-			it('can use a custom schema', async() => {
+			it('can use a custom schema', async () => {
 				const schemaInstance = {
-						getGraphqlDefs: jest.fn(),
-						getTypes: jest.fn(),
-						onChange: jest.fn(),
-					}
+					getGraphqlDefs: jest.fn(),
+					getTypes: jest.fn(),
+					onChange: jest.fn(),
+				};
 
-				schemaInstance.getGraphqlDefs.mockReturnValue([])
-				schemaInstance.getTypes.mockReturnValue([])
-				schemaInstance.onChange.mockImplementation(func => func())
-				const {listenForSchemaChanges} = getGraphqlApi({
+				schemaInstance.getGraphqlDefs.mockReturnValue([]);
+				schemaInstance.getTypes.mockReturnValue([]);
+				schemaInstance.onChange.mockImplementation(func => func());
+				const { listenForSchemaChanges } = getGraphqlApi({
 					schemaInstance,
-					documentStore: {}
+					documentStore: {},
 				});
 
 				listenForSchemaChanges();
-				expect(schemaInstance.onChange).toHaveBeenCalled()
-				expect(schemaInstance.getGraphqlDefs).toHaveBeenCalled()
-				expect(schemaInstance.getTypes).toHaveBeenCalled()
-
+				expect(schemaInstance.onChange).toHaveBeenCalled();
+				expect(schemaInstance.getGraphqlDefs).toHaveBeenCalled();
+				expect(schemaInstance.getTypes).toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/tc-api-graphql/__tests__/graphql.spec.js
+++ b/packages/tc-api-graphql/__tests__/graphql.spec.js
@@ -356,5 +356,30 @@ describe('graphql', () => {
 					},
 				});
 		});
+
+		describe('custom schema', () => {
+
+			it('can use a custom schema', async() => {
+				const schemaInstance = {
+						getGraphqlDefs: jest.fn(),
+						getTypes: jest.fn(),
+						onChange: jest.fn(),
+					}
+
+				schemaInstance.getGraphqlDefs.mockReturnValue([])
+				schemaInstance.getTypes.mockReturnValue([])
+				schemaInstance.onChange.mockImplementation(func => func())
+				const {listenForSchemaChanges} = getGraphqlApi({
+					schemaInstance,
+					documentStore: {}
+				});
+
+				listenForSchemaChanges();
+				expect(schemaInstance.onChange).toHaveBeenCalled()
+				expect(schemaInstance.getGraphqlDefs).toHaveBeenCalled()
+				expect(schemaInstance.getTypes).toHaveBeenCalled()
+
+			});
+		});
 	});
 });

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -2,7 +2,6 @@ const { logger } = require('@financial-times/tc-api-express-logger');
 const { onChange } = require('@financial-times/tc-schema-sdk');
 const { sendSchemaToS3 } = require('@financial-times/tc-schema-publisher');
 const { getApolloMiddleware } = require('./lib/get-apollo-middleware');
-let instanceId = 0;
 const getGraphqlApi = ({
 	documentStore,
 	republishSchema,
@@ -14,10 +13,8 @@ const getGraphqlApi = ({
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
-	const instance = instanceId++;
 
 	const updateAPI = () => {
-
 		try {
 			graphqlHandler = getApolloMiddleware({
 				documentStore,
@@ -55,7 +52,9 @@ const getGraphqlApi = ({
 	};
 
 	return {
-		graphqlHandler: (...args) => graphqlHandler(...args),
+		graphqlHandler: (...args) => {
+			return graphqlHandler(...args)
+		},
 		isSchemaUpdating: () => schemaDidUpdate,
 		listenForSchemaChanges: () => onChange(updateAPI),
 	};

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -2,6 +2,7 @@ const { logger } = require('@financial-times/tc-api-express-logger');
 const { onChange } = require('@financial-times/tc-schema-sdk');
 const { sendSchemaToS3 } = require('@financial-times/tc-schema-publisher');
 const { getApolloMiddleware } = require('./lib/get-apollo-middleware');
+
 const getGraphqlApi = ({
 	documentStore,
 	republishSchema,
@@ -53,7 +54,7 @@ const getGraphqlApi = ({
 
 	return {
 		graphqlHandler: (...args) => {
-			return graphqlHandler(...args)
+			return graphqlHandler(...args);
 		},
 		isSchemaUpdating: () => schemaDidUpdate,
 		listenForSchemaChanges: () => onChange(updateAPI),

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -1,5 +1,5 @@
 const { logger } = require('@financial-times/tc-api-express-logger');
-const { onChange } = require('@financial-times/tc-schema-sdk');
+const tcSchemaSdk = require('@financial-times/tc-schema-sdk');
 const { sendSchemaToS3 } = require('@financial-times/tc-schema-publisher');
 const { getApolloMiddleware } = require('./lib/get-apollo-middleware');
 
@@ -12,6 +12,7 @@ const getGraphqlApi = ({
 	excludeTypes,
 	schemaInstance,
 } = {}) => {
+	const {onChange} = schemaInstance || tcSchemaSdk
 	let schemaDidUpdate;
 	let graphqlHandler;
 
@@ -53,9 +54,7 @@ const getGraphqlApi = ({
 	};
 
 	return {
-		graphqlHandler: (...args) => {
-			return graphqlHandler(...args);
-		},
+		graphqlHandler: (...args) => graphqlHandler(...args),
 		isSchemaUpdating: () => schemaDidUpdate,
 		listenForSchemaChanges: () => onChange(updateAPI),
 	};

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -27,9 +27,6 @@ const getGraphqlApi = ({
 				schemaInstance,
 			});
 
-
-			console.log({instance, graphqlHandler})
-
 			schemaDidUpdate = true;
 			logger.info({ event: 'GRAPHQL_SCHEMA_UPDATED' });
 
@@ -58,10 +55,7 @@ const getGraphqlApi = ({
 	};
 
 	return {
-		graphqlHandler: (...args) => {
-			console.log({instance, graphqlHandler})
-			return graphqlHandler(...args)
-		},
+		graphqlHandler: (...args) => graphqlHandler(...args),
 		isSchemaUpdating: () => schemaDidUpdate,
 		listenForSchemaChanges: () => onChange(updateAPI),
 	};

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -2,7 +2,7 @@ const { logger } = require('@financial-times/tc-api-express-logger');
 const { onChange } = require('@financial-times/tc-schema-sdk');
 const { sendSchemaToS3 } = require('@financial-times/tc-schema-publisher');
 const { getApolloMiddleware } = require('./lib/get-apollo-middleware');
-
+let instanceId = 0;
 const getGraphqlApi = ({
 	documentStore,
 	republishSchema,
@@ -10,18 +10,25 @@ const getGraphqlApi = ({
 	typeDefs = [],
 	resolvers = {},
 	excludeTypes,
+	schemaInstance,
 } = {}) => {
 	let schemaDidUpdate;
 	let graphqlHandler;
+	const instance = instanceId++;
 
 	const updateAPI = () => {
+
 		try {
 			graphqlHandler = getApolloMiddleware({
 				documentStore,
 				typeDefs,
 				resolvers,
 				excludeTypes,
+				schemaInstance,
 			});
+
+
+			console.log({instance, graphqlHandler})
 
 			schemaDidUpdate = true;
 			logger.info({ event: 'GRAPHQL_SCHEMA_UPDATED' });
@@ -51,7 +58,10 @@ const getGraphqlApi = ({
 	};
 
 	return {
-		graphqlHandler: (...args) => graphqlHandler(...args),
+		graphqlHandler: (...args) => {
+			console.log({instance, graphqlHandler})
+			return graphqlHandler(...args)
+		},
 		isSchemaUpdating: () => schemaDidUpdate,
 		listenForSchemaChanges: () => onChange(updateAPI),
 	};

--- a/packages/tc-api-graphql/index.js
+++ b/packages/tc-api-graphql/index.js
@@ -12,7 +12,7 @@ const getGraphqlApi = ({
 	excludeTypes,
 	schemaInstance,
 } = {}) => {
-	const {onChange} = schemaInstance || tcSchemaSdk
+	const { onChange } = schemaInstance || tcSchemaSdk;
 	let schemaDidUpdate;
 	let graphqlHandler;
 

--- a/packages/tc-api-graphql/lib/get-apollo-middleware.js
+++ b/packages/tc-api-graphql/lib/get-apollo-middleware.js
@@ -13,6 +13,7 @@ const getApolloMiddleware = ({
 	typeDefs,
 	resolvers,
 	excludeTypes,
+	schemaInstance,
 }) => {
 	const apollo = new ApolloServer({
 		subscriptions: false,
@@ -21,6 +22,7 @@ const getApolloMiddleware = ({
 			typeDefs,
 			resolvers,
 			excludeTypes,
+			schemaInstance,
 		}),
 		context: ({
 			req: { headers },
@@ -31,7 +33,10 @@ const getApolloMiddleware = ({
 			const context = {
 				driver,
 				headers,
-				trace: new Tracer(getContextByRequestId(requestId)),
+				trace: new Tracer(
+					getContextByRequestId(requestId),
+					schemaInstance,
+				),
 			};
 
 			if (documentStore) {

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -2,7 +2,7 @@ const logger = require('@financial-times/n-logger').default;
 const { makeAugmentedSchema } = require('neo4j-graphql-js');
 const { applyMiddleware } = require('graphql-middleware');
 const { parse } = require('graphql');
-const { getGraphqlDefs, getTypes } = require('@financial-times/tc-schema-sdk');
+const tcSchema = require('@financial-times/tc-schema-sdk');
 const { middleware: requestTracer } = require('./request-tracer');
 
 const resolveDocumentProperty = async ({ code }, args, context, info) => {
@@ -16,9 +16,8 @@ const resolveDocumentProperty = async ({ code }, args, context, info) => {
 	return record[info.fieldName];
 };
 
-const getDocumentResolvers = () => {
+const getDocumentResolvers = types => {
 	const typeResolvers = {};
-	const types = getTypes();
 	types.forEach(type => {
 		const nodeProperties = type.properties;
 		const documentResolvers = {};
@@ -39,8 +38,10 @@ const getAugmentedSchema = ({
 	typeDefs: extendedTypeDefs,
 	resolvers: extendedResolvers,
 	excludeTypes,
+	schemaInstance,
 }) => {
-	const resolvers = documentStore ? getDocumentResolvers() : {};
+	const { getGraphqlDefs, getTypes } = schemaInstance || tcSchema;
+	const resolvers = documentStore ? getDocumentResolvers(getTypes()) : {};
 	const typeDefs = getGraphqlDefs();
 
 	if (extendedTypeDefs.length) {

--- a/packages/tc-api-graphql/lib/request-tracer.js
+++ b/packages/tc-api-graphql/lib/request-tracer.js
@@ -2,9 +2,10 @@ const { getType } = require('@financial-times/tc-schema-sdk');
 const { logger } = require('@financial-times/tc-api-express-logger');
 
 class Tracer {
-	constructor(context) {
+	constructor(context, schemaInstance) {
 		this.map = {};
 		this.context = { ...context };
+		this.getType = schemaInstance ? schemaInstance.getType : getType;
 	}
 
 	collect(type, field) {
@@ -17,7 +18,7 @@ class Tracer {
 			Object.entries(this.map).forEach(([type, fields]) => {
 				let properties;
 				try {
-					({ properties } = getType(type));
+					({ properties } = this.getType(type));
 				} catch (err) {
 					properties = {};
 				}


### PR DESCRIPTION
## Why?

We have _a_ way of spinning up a beta API for Biz Ops (so we can run risk register off a WIP model) but
- It requires spinning up a new app on a new host name we need to share around
- Using an authentication method that differs from normal (API_KEY rather than x-api-key)
- To use the graphql explorer with it you need to spin up biz-ops-admin with the schema url and api host overridden

It feels altogether quite hacky

It'd be nice if you could call the usual test api but somehow tell it 'use the beta schema for this request'

## What?
tc-api-graphql only has a handful of places it uses tc-schema-sdk
tc-schema-sdk also - mainly in order to make it easier to test - allows creating multiple instances, all configured differently

So it's relatively straightforward to pass in a schema instance to it and use that instead of the global one.

This allows us (as the POC in the demo app demonstrates) to spin up a beta graphql endpoint within the same app as the main graphql endpoint. Biz ops admin test's api explorer can then be...

... ah no, it won't work because
- the api explorer doesn't contact the api directly - it gets proxied by a /graphql route of the admin app
- still doesn't allow us to use the admin screens to write Risk data

Boooooo

But leaving this PR here for now as it's been interesting to explore, might be an interesting learning experience to review, and maybe those 2 points above are not the blockers I think they are, and somebody else might be able to suggest a way through