### PR TITLE
Add fieldset description

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
+version: v1.14.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-ACORN-559469:
@@ -492,5 +492,14 @@ ignore:
     - '@financial-times/tc-api-rest-handlers > @financial-times/tc-api-db-manager > next-metrics > lodash':
         reason: Wait for lodash fix
         expires: '2020-05-31T15:33:56.703Z'
-patch: {}
-
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - neo4j-graphql-js > lodash:
+        patched: '2020-06-16T09:38:58.078Z'
+    - '@financial-times/tc-api-db-manager > next-metrics > lodash':
+        patched: '2020-06-16T09:38:58.078Z'
+    - '@financial-times/tc-api-rest-handlers > @financial-times/tc-api-db-manager > next-metrics > lodash':
+        patched: '2020-06-16T09:38:58.078Z'
+    - next-metrics > lodash:
+        patched: '2020-06-16T09:38:58.078Z'

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,12 @@ cypress-open:
 ### Runs tests for pages (assumes the app is running in another terminal)
 cypress-run-page:
 	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js" --video false
+	cypress run --spec "packages/tc-ui/src/pages/**/__tests__/**.cyp.js" --config video=false
 
 ### Runs tests for primitive components (assumes the app is running in another terminal)
 cypress-run-primitives:
 	TREECREEPER_TEST=true TREECREEPER_SCHEMA_DIRECTORY=example-schema \
-	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js" --video false
+	cypress run --spec "packages/tc-ui/src/primitives/**/__tests__/**.cyp.js" --config video=false
 
 # Deploy
 

--- a/example-schema/type-hierarchy.yaml
+++ b/example-schema/type-hierarchy.yaml
@@ -8,3 +8,4 @@ test:
     - RestrictedType
     - OddCodeType
     - MVRType
+    - FieldsetType

--- a/example-schema/types/FieldsetType.yaml
+++ b/example-schema/types/FieldsetType.yaml
@@ -1,0 +1,33 @@
+name: FieldsetType
+description: Description of FieldsetType.
+properties:
+  code:
+    type: Code
+    unique: true
+    canIdentify: true
+    description: Code description.
+    pattern: CODE
+    label: Code label
+    fieldset: fieldsetA
+  prop1:
+    type: Word
+    description: fieldsetA prop1.
+    label: fieldsetA prop1
+    fieldset: fieldsetA
+  prop2:
+    type: Word
+    description: fieldsetB prop2.
+    label: fieldsetB prop2
+    fieldset: fieldsetB
+  prop3:
+    type: Word
+    description: fieldsetB prop3.
+    label: fieldsetB prop3
+    fieldset: fieldsetB
+
+fieldsets:
+  fieldsetA:
+    heading: I am a fieldset
+  fieldsetB:
+    heading: Fieldset B
+    description: I have a lovely description.

--- a/example-schema/types/FieldsetType.yaml
+++ b/example-schema/types/FieldsetType.yaml
@@ -27,7 +27,7 @@ properties:
 
 fieldsets:
   fieldsetA:
-    heading: I am a fieldset
+    heading: Fieldset A
   fieldsetB:
     heading: Fieldset B
     description: I have a lovely description.

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "@financial-times/tc-ui": "file:packages/tc-ui",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
-    "graphql-playground-middleware-express": "^1.7.12",
+    "graphql-playground-middleware-express": "^1.7.14",
     "http-errors": "^1.7.3",
     "module-alias": "^2.2.2",
     "neo4j-driver": "^1.7.6",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "snyk": "^1.316.1"
+    "snyk": "^1.341.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",
@@ -56,7 +56,7 @@
     "webpack-manifest-plugin": "^2.2.0"
   },
   "scripts": {
-    "test": "make test",
+    "test": "snyk test && make test",
     "postinstall": "athloi exec npm i -- --no-package-lock",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -149,10 +149,39 @@ const LinkToRecord = ({ id, type, value, linkGenerator }) => {
 	);
 };
 
+const Fieldset = ({
+	type,
+	code,
+	heading,
+	description,
+	name,
+	includeEditLink,
+	children,
+}) => {
+	return (
+		<fieldset
+			className={`o-layout-typography fieldset-treecreeper fieldset-${name}`}
+		>
+			<SectionHeader
+				type={type}
+				code={code}
+				title={heading}
+				includeEditLink={includeEditLink}
+			/>
+			<div className="description-text o-forms-title__prompt">
+				{description}
+				<p />
+			</div>
+			{children}
+		</fieldset>
+	);
+};
+
 module.exports = {
 	LinkToRecord,
 	Concept,
 	SectionHeader,
 	LabelledPrimitive,
 	MetaProperties,
+	Fieldset,
 };

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -155,7 +155,7 @@ const Fieldset = ({
 	heading,
 	description,
 	name,
-	includeEditLink,
+	isInViewMode,
 	children,
 }) => {
 	const fieldSetcontent = (
@@ -164,7 +164,7 @@ const Fieldset = ({
 				type={type}
 				code={code}
 				title={heading}
-				includeEditLink={includeEditLink}
+				includeEditLink={isInViewMode}
 			/>
 			<div
 				className={`description-text o-forms-title__prompt fieldset-${name}-description`}
@@ -176,7 +176,7 @@ const Fieldset = ({
 		</>
 	);
 
-	const wrapper = includeEditLink ? (
+	const wrapper = isInViewMode ? (
 		<section
 			key={name}
 			className={`o-layout-typography fieldset-treecreeper fieldset-${name}`}

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -168,7 +168,9 @@ const Fieldset = ({
 				title={heading}
 				includeEditLink={includeEditLink}
 			/>
-			<div className="description-text o-forms-title__prompt">
+			<div
+				className={`description-text o-forms-title__prompt fieldset-${name}-description`}
+			>
 				{description}
 				<p />
 			</div>

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -158,10 +158,8 @@ const Fieldset = ({
 	includeEditLink,
 	children,
 }) => {
-	return (
-		<fieldset
-			className={`o-layout-typography fieldset-treecreeper fieldset-${name}`}
-		>
+	const fieldSetcontent = (
+		<>
 			<SectionHeader
 				type={type}
 				code={code}
@@ -175,8 +173,26 @@ const Fieldset = ({
 				<p />
 			</div>
 			{children}
+		</>
+	);
+
+	const wrapper = includeEditLink ? (
+		<section
+			key={name}
+			className={`o-layout-typography fieldset-treecreeper fieldset-${name}`}
+		>
+			{fieldSetcontent}
+		</section>
+	) : (
+		<fieldset
+			key={name}
+			className={`o-layout-typography fieldset-treecreeper fieldset-${name}`}
+		>
+			{fieldSetcontent}
 		</fieldset>
 	);
+
+	return wrapper;
 };
 
 module.exports = {

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-create-type.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-create-type.cyp.js
@@ -188,4 +188,25 @@ describe('End-to-end - record creation', () => {
 			cy.get('#children').should('have.length', 1);
 		});
 	});
+	describe('Fieldset displays when creating type', () => {
+		beforeEach(() => {
+			cy.visit(`/FieldsetType/create`);
+		});
+		it('displays fieldset heading for fieldsets', () => {
+			cy.get('.fieldset-fieldsetA').should('exist');
+			cy.get('#fieldset-a').contains('Fieldset A');
+			cy.get('.fieldset-fieldsetB').should('exist');
+			cy.get('#fieldset-b').contains('Fieldset B');
+		});
+
+		it('displays fieldset description when provided for fieldsets', () => {
+			cy.get('.fieldset-fieldsetB-description').should('exist');
+			cy.get('.fieldset-fieldsetB-description').should(
+				'have.text',
+				'I have a lovely description.',
+			);
+			cy.get('.fieldset-fieldsetA-description').should('exist');
+			cy.get('.fieldset-fieldsetA-description').should('have.text', '');
+		});
+	});
 });

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
@@ -13,6 +13,7 @@ const {
 	visitMainTypePage,
 	save,
 	setLockedRecord,
+	visitFieldsetTypePage,
 } = require('../../../test-helpers/cypress');
 
 describe('End-to-end - edit record', () => {
@@ -278,5 +279,59 @@ describe('End-to-end - edit record', () => {
 			'have.text',
 			'This value: e2e-demo',
 		);
+	});
+	describe('Fieldset display', () => {
+		beforeEach(() => {
+			cy.wrap(
+				createType({
+					code: 'Fieldset-demo',
+					type: 'FieldsetType',
+				}),
+			).then(() => visitFieldsetTypePage('Fieldset-demo'));
+		});
+		describe('view mode', () => {
+			it('displays fieldset heading for fieldsets', () => {
+				cy.get('.fieldset-fieldsetA').should('exist');
+				cy.get('#fieldset-a').should('have.text', 'Fieldset A');
+				cy.get('.fieldset-fieldsetB').should('exist');
+				cy.get('#fieldset-b').should('have.text', 'Fieldset B');
+			});
+
+			it('displays fieldset description when provided for fieldsets', () => {
+				cy.get('.fieldset-fieldsetB-description').should('exist');
+				cy.get('.fieldset-fieldsetB-description').should(
+					'have.text',
+					'I have a lovely description.',
+				);
+				cy.get('.fieldset-fieldsetA-description').should('exist');
+				cy.get('.fieldset-fieldsetA-description').should(
+					'have.text',
+					'',
+				);
+			});
+		});
+		describe('edit mode', () => {
+			it('displays fieldset heading for fieldsets', () => {
+				visitEditPage();
+				cy.get('.fieldset-fieldsetA').should('exist');
+				cy.get('#fieldset-a').contains('Fieldset A');
+				cy.get('.fieldset-fieldsetB').should('exist');
+				cy.get('#fieldset-b').contains('Fieldset B');
+			});
+			it('displays fieldset description when provided for fieldsets', () => {
+				visitEditPage();
+
+				cy.get('.fieldset-fieldsetB-description').should('exist');
+				cy.get('.fieldset-fieldsetB-description').should(
+					'have.text',
+					'I have a lovely description.',
+				);
+				cy.get('.fieldset-fieldsetA-description').should('exist');
+				cy.get('.fieldset-fieldsetA-description').should(
+					'have.text',
+					'',
+				);
+			});
+		});
 	});
 });

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -1,7 +1,7 @@
 const React = require('react');
 const { getEnums, rawData } = require('@financial-times/tc-schema-sdk');
 const { FormError } = require('../../lib/components/messages');
-const { Concept, SectionHeader } = require('../../lib/components/structure');
+const { Concept, Fieldset } = require('../../lib/components/structure');
 const { getValue } = require('../../lib/mappers/get-value');
 const { SaveButton, CancelButton } = require('../../lib/components/buttons');
 
@@ -116,14 +116,17 @@ const EditForm = props => {
 						/>
 					</div>
 					{Object.entries(schema.fieldsets).map(
-						([name, { heading, properties }], index) => (
-							<fieldset
-								className={`fieldset-treecreeper fieldset-${name}`}
+						(
+							[name, { heading, properties, description }],
+							index,
+						) => (
+							<Fieldset
 								key={index}
+								name={name}
+								heading={heading}
+								properties={properties}
+								description={description}
 							>
-								<div className="o-layout-typography">
-									<SectionHeader title={heading} />
-								</div>
 								<PropertyInputs
 									hasError={!!error}
 									fields={properties}
@@ -131,7 +134,7 @@ const EditForm = props => {
 									type={type}
 									assignComponent={assignComponent}
 								/>
-							</fieldset>
+							</Fieldset>
 						),
 					)}
 					<input

--- a/packages/tc-ui/src/pages/view/template.jsx
+++ b/packages/tc-ui/src/pages/view/template.jsx
@@ -96,7 +96,7 @@ const View = props => {
 					</div>
 					<div className="o-layout-typography">
 						{Object.entries(schema.fieldsets).map(
-							([name, { heading, properties }]) => (
+							([name, { heading, description, properties }]) => (
 								<section
 									className={`fieldset-treecreeper fieldset-${name}`}
 								>
@@ -106,6 +106,10 @@ const View = props => {
 										title={heading}
 										includeEditLink
 									/>
+									<div className="description-text o-forms-title__prompt">
+										{description}
+										<p />
+									</div>
 									<dl className="treecreeper-properties-list">
 										<Properties
 											fields={properties}

--- a/packages/tc-ui/src/pages/view/template.jsx
+++ b/packages/tc-ui/src/pages/view/template.jsx
@@ -103,7 +103,7 @@ const View = props => {
 									heading={heading}
 									description={description}
 									name={name}
-									includeEditLink
+									isInViewMode
 								>
 									<dl className="treecreeper-properties-list">
 										<Properties

--- a/packages/tc-ui/src/pages/view/template.jsx
+++ b/packages/tc-ui/src/pages/view/template.jsx
@@ -3,8 +3,8 @@ const { FormError } = require('../../lib/components/messages');
 const {
 	Concept,
 	LabelledPrimitive,
-	SectionHeader,
 	MetaProperties,
+	Fieldset,
 } = require('../../lib/components/structure');
 const { EditButton, DeleteButton } = require('../../lib/components/buttons');
 
@@ -97,19 +97,14 @@ const View = props => {
 					<div className="o-layout-typography">
 						{Object.entries(schema.fieldsets).map(
 							([name, { heading, description, properties }]) => (
-								<section
-									className={`fieldset-treecreeper fieldset-${name}`}
+								<Fieldset
+									type={schema.type}
+									code={data.code}
+									heading={heading}
+									description={description}
+									name={name}
+									includeEditLink
 								>
-									<SectionHeader
-										type={schema.type}
-										code={data.code}
-										title={heading}
-										includeEditLink
-									/>
-									<div className="description-text o-forms-title__prompt">
-										{description}
-										<p />
-									</div>
 									<dl className="treecreeper-properties-list">
 										<Properties
 											fields={properties}
@@ -117,7 +112,7 @@ const View = props => {
 											assignComponent={assignComponent}
 										/>
 									</dl>
-								</section>
+								</Fieldset>
 							),
 						)}
 						<p>

--- a/packages/tc-ui/src/test-helpers/cypress.js
+++ b/packages/tc-ui/src/test-helpers/cypress.js
@@ -68,6 +68,11 @@ const visitMainTypePage = () => {
 	cy.url().should('contain', `/MainType/${code}`);
 };
 
+const visitFieldsetTypePage = typeCode => {
+	cy.visit(`/FieldsetType/${typeCode}`);
+	cy.url().should('contain', `/FieldsetType/${typeCode}`);
+};
+
 const visitMVRTypePage = () => {
 	cy.visit(`/MVRType/${code}`);
 	cy.url().should('contain', `/MVRType/${code}`);
@@ -472,6 +477,7 @@ module.exports = {
 	visitEditPage,
 	visitMainTypePage,
 	visitMVRTypePage,
+	visitFieldsetTypePage,
 	save,
 	populateMinimumViableFields,
 	resetDb,


### PR DESCRIPTION
## Why?

-  [ticket](https://financialtimes.atlassian.net/browse/RE-1844)

It’s possible to add a description for a fieldset in the schema but this isn’t used anywhere

We have made use of these within risk model 

## What?

- Created a new type in the demo schema `FieldsetType`
- add code to use the fieldset description on the edit and view pages
- added tests for create/view/edit  views to confirm fieldsets and description displays as expected. 

### Anything in particular you'd like to highlight to reviewers?

n/a

## Screenshots / Images

![Screenshot 2020-06-15 at 16 28 56](https://user-images.githubusercontent.com/28360633/84676856-df1b9900-af25-11ea-912e-da28396b64d6.png)

![Screenshot 2020-06-15 at 16 29 09](https://user-images.githubusercontent.com/28360633/84676884-e347b680-af25-11ea-88e6-372c3d825203.png)

