### PR TITLE
prevent blocking of empty strings by validation patterns

### DIFF
--- a/example-schema/type-hierarchy.yaml
+++ b/example-schema/type-hierarchy.yaml
@@ -9,3 +9,4 @@ test:
     - OddCodeType
     - MVRType
     - FieldsetType
+    - ValidatedType

--- a/example-schema/types/ValidatedType.yaml
+++ b/example-schema/types/ValidatedType.yaml
@@ -1,0 +1,15 @@
+name: ValidatedType
+description: ValidatedType description.
+properties:
+  code:
+    type: Code
+    unique: true
+    canIdentify: true
+    description: Code description.
+    label: Code label
+    pattern: CODE
+  someString:
+    type: Word
+    description: Word description.
+    label: Word label
+    pattern: ATTRIBUTE_NAME

--- a/packages/tc-api-rest-handlers/__tests__/patch-create.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-create.spec.js
@@ -98,6 +98,46 @@ describe('rest PATCH create', () => {
 				});
 		});
 
+		it('writes successfully when empty string validated against a pattern', async () => {
+			const { status, body } = await patchHandler()({
+				type: 'ValidatedType',
+				code: `${namespace}-validated`,
+				body: { someString: '' },
+				metadata: getMetaPayload(),
+			});
+
+			expect(status).toBe(201);
+			expect(body).toMatchObject({
+				code: `${namespace}-validated`,
+			});
+
+			await neo4jTest('ValidatedType', `${namespace}-validated`)
+				.exists()
+				.notMatch({
+					someString: expect.any(String),
+				});
+		});
+
+		it('writes successfully when null value validated against a pattern', async () => {
+			const { status, body } = await patchHandler()({
+				type: 'ValidatedType',
+				code: `${namespace}-validated`,
+				body: {},
+				metadata: getMetaPayload(),
+			});
+
+			expect(status).toBe(201);
+			expect(body).toMatchObject({
+				code: `${namespace}-validated`,
+			});
+
+			await neo4jTest('ValidatedType', `${namespace}-validated`)
+				.exists()
+				.notMatch({
+					someString: expect.any(String),
+				});
+		});
+
 		it('sets Date property', async () => {
 			const date = '2019-01-09';
 			const { status, body } = await basicHandler({

--- a/packages/tc-api-rest-handlers/lib/validation.js
+++ b/packages/tc-api-rest-handlers/lib/validation.js
@@ -94,9 +94,22 @@ const validateMetadata = ({
 	}
 };
 
+const coerceEmptyStringsToNull = ({ body }) => {
+	Object.entries(body).forEach(([propName, value]) => {
+		if (value === '') {
+			body[propName] = null;
+		}
+	});
+};
+
 const validateInput = input => {
 	validateParams(input);
 	if (input.body) {
+		// TODO need to do something similar for relationship properties
+		// and consolidate with eth isNull checks in diff-properties.js
+		// Long story short, if we convert everything to null early in here
+		// then diff properties can probably be simplified
+		coerceEmptyStringsToNull(input);
 		validateBody(input);
 	}
 	validateMetadata(input);

--- a/packages/tc-api-rest-handlers/lib/validation.js
+++ b/packages/tc-api-rest-handlers/lib/validation.js
@@ -106,7 +106,7 @@ const validateInput = input => {
 	validateParams(input);
 	if (input.body) {
 		// TODO need to do something similar for relationship properties
-		// and consolidate with eth isNull checks in diff-properties.js
+		// and consolidate with the isNull checks in diff-properties.js
 		// Long story short, if we convert everything to null early in here
 		// then diff properties can probably be simplified
 		coerceEmptyStringsToNull(input);


### PR DESCRIPTION
## Why?

@nl-ria  found a bug whereby empty strings in fields that used a vaildation pattern were being rejected. This is because the pattern was running against all strings, even empty ones.

## What?
Adds a test and coerces empty strings to null early. Empty strings are already treated as (or are supposed to be, at least) null when writing to the database, so this shifts that coercion earlier in order to skip validation.

Similar thing needs to happen for properties on relationships - i will add an issue to capture that requirement, but won't tackle it here because it'll get way more complicated and does not actually apply to any of our Biz Ops data at the moment - we have no string-validtead properties written onto relationships

I do now wonder if there's been a bug for a while that means we've been saving empty strings to the DB - I will do some kind of audit on the data