### PR TITLE
avoid being unable to suggest items with same code

### DIFF
--- a/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
+++ b/packages/tc-ui/src/primitives/relationship/lib/relationship-picker.jsx
@@ -150,7 +150,7 @@ class RelationshipPicker extends React.Component {
 	}
 
 	fetchSuggestions({ value }) {
-		const { parentCode } = this.props;
+		const { parentCode, parentType, type } = this.props;
 
 		if (value.length < MIN_QUERY_LENGTH || this.state.isFetching) {
 			return;
@@ -172,7 +172,9 @@ class RelationshipPicker extends React.Component {
 							suggestion =>
 								!selectedRelationships.find(
 									({ code }) => code === suggestion.code,
-								) && parentCode !== suggestion.code,
+								) &&
+								(parentType !== type ||
+									parentCode !== suggestion.code),
 						),
 					isFetching: false,
 				}));


### PR DESCRIPTION
## Why?

When e.g. adding system dependencies to a system we want to avoid something being a dependency of itself, so we filter out suggestions with the same code as the current record.

_But_ this meant that if adding record of typeA to a record of typeB, but they both had the same code, then the suggestion would be filtered out, and the relation souldn't be created

## What?
Checks for type as well as code identity