### PR TITLE
fix empty input for int type should defaulting to 0 

### DIFF
--- a/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
+++ b/packages/tc-ui/src/primitives/number/__tests__/e2e-record-number.cyp.js
@@ -65,6 +65,14 @@ describe('End-to-end - record Number type', () => {
 			visitEditPage();
 			cy.get('input[name=someInteger]').should('have.value', '0');
 		});
+
+		it('does not parse empty input to zero', () => {
+			save();
+			cy.url().should('contain', '/MainType/e2e-demo');
+			cy.get('#someInteger').should('not.exist');
+			visitEditPage();
+			cy.get('input[name=someInteger]').should('have.value', '');
+		});
 	});
 
 	describe('float', () => {

--- a/packages/tc-ui/src/primitives/number/server.jsx
+++ b/packages/tc-ui/src/primitives/number/server.jsx
@@ -4,6 +4,9 @@ module.exports = {
 	name: 'Number',
 	EditComponent: text.EditComponent,
 	ViewComponent: text.ViewComponent,
-	parser: value => (Number.isNaN(Number(value)) ? value : Number(value)),
+	parser: value => {
+		if (value === '') return null;
+		return Number.isNaN(Number(value)) ? value : Number(value);
+	},
 	hasValue: value => value || value === 0,
 };


### PR DESCRIPTION
## Why?

### Bug Fix

-   [ticket](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1169&projectKey=RE&modal=detail&selectedIssue=RE-1852)
-   if you save the form for a risk with empty strings in the number fields, they get saved as zeros. 
expected behaviour - save as null

## What?

-   Updated number parser to check for empty string, and if so return null entry to be sent to treecreeper API 
-   End user expected behaviour of this is that these fields will not display on success screen. Added test to replicate this. 

### Anything in particular you'd like to highlight to reviewers?

Mention here sections of code which you would like reviewers to pay extra attention to, for example:

_I have made a few assumptions here - there may be edge cases or further places this needs updating_  

## Screenshots / Images

<img width="395" alt="Screenshot 2020-06-23 at 11 27 49" src="https://user-images.githubusercontent.com/28360633/85393259-9b87e700-b544-11ea-84a5-95a4c0f706c8.png">

<img width="840" alt="Screenshot 2020-06-23 at 11 31 21" src="https://user-images.githubusercontent.com/28360633/85393571-223cc400-b545-11ea-8576-6464b3938eec.png">

