### PR TITLE
Truncate strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.7.0",
     "@financial-times/athloi": "^1.0.0-beta.29",
-    "@financial-times/rel-engage": "^7.3.3",
+    "@financial-times/rel-engage": "^7.4.3",
     "@financial-times/tc-api-graphql": "file:./packages/tc-api-graphql",
     "aws-sdk": "^2.611.0",
     "babel-loader": "^8.0.6",

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -31,10 +31,23 @@ const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 				? data[`${propertyName}_rel`] || data[propertyName]
 				: data[propertyName];
 
+			/**
+			 * Sending the entire record to the client multiple times can increase the payload immensely
+			 * However some components rely on this (eg "decommissioned" functionality)
+			 * As a workaround for now, truncate long text fields
+			 * TODO: think of a better way to be selective about what we send
+			 */
+			const clientSideRecord = {};
+			Object.entries(data).forEach(([key, value]) => {
+				clientSideRecord[key] =
+					typeof value !== 'string' || value.length < 25
+						? value
+						: `${value.substring(0, 24)}…`;
+			});
 			const viewModel = {
 				hasError,
 				parentCode: data.code,
-				entireRecord: data,
+				entireRecord: clientSideRecord,
 				propertyName,
 				value: getValue(propDef, itemValue),
 				dataType: propDef.type,

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -47,7 +47,7 @@ const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 				.filter(
 					([key]) => 'key' in data && fields[key].type === 'Document',
 				)
-				.forEach(([key, value]) => {
+				.forEach(([key]) => {
 					clientSideRecord[key] = `${data[key].substring(0, 24)}…`;
 				});
 


### PR DESCRIPTION
## Why?

@wheresrhys reported that https://biz-ops-test.in.ft.com/System/sso-subscription-service-my-licence/edit was returning a 503.  Based on the logs in splunk, this was caused by a 413 entity too large error.  According to [the AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html), the limit payload limit for lambdas is 6MB
For this particular system (at least based on data in test) we're returning a payload of 11.4MB
This looks to be caused by each base64 encoded image included in troubleshooting section being output in the payload 20 times.

## What?

Rather than outputting the entire biz-ops record as a json-encoded attribute for every component, output the same structure, but truncate any large strings at the top level

### Anything in particular you'd like to highlight to reviewers?

This isn't the nicest solution, but as I'm not familiar with all the interdependencies of the various treecreeper bits, I wanted to keep any changes to the tc/biz-ops interface as minimal as possible to avoid breaking anything.

I the longer term, I think we should consider removing the `entireRecord` attribute (or at least only include it once per page, rather than per component)

## Screenshots / Images

Before
<img width="865" alt="11.4MB" src="https://user-images.githubusercontent.com/428847/85550433-dce9c680-b618-11ea-9d7d-66b143d9dafc.png">

After
<img width="865" alt="610kB" src="https://user-images.githubusercontent.com/428847/85550454-e3783e00-b618-11ea-8180-7bd7bf7965af.png">
