### PR TITLE
avoid outputting cypher properties in the ui

### DIFF
--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -145,3 +145,9 @@ properties:
     type: AnotherEnum
     description: An enum that has something next to it.
     label: Multiple choice next to another thing
+  cypherThing:
+    label: Cypher haha
+    description: Cypher hahahahaha.
+    type: ChildType
+    cypher: "MATCH (this)-[:HAS_CHILD]->(c) RETURN c"
+    hasMany: true

--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -104,6 +104,7 @@ The full object structure returned by getType() can been seen [here](GETTYPE.md)
 -   `withRelationships` [default: `true`]: Include the relationships for the type, expressed as graphql property definitions.
 -   `groupProperties` [default: `false`]: Each property may have a `fieldset` attribute. Setting `groupProperties: true` removes the `properties` object from the data, and replaces it with `fieldsets`, where all properties are then grouped by fieldset
 -   `includeMetaFields` [default: `false`]: Determines whether to include metadatafields (prefixed with `_`) in the schema object returned
+-   `includeMetaFields` [default: `true`]: Determines whether to include synthetic fields (those using a custom cypher statement) in the schema object returned
 -   `useMinimumViableRecord` [default: `false`]: If `groupProperties` is `true`, this will put any fields defined as being part of the minimum viable record (see [model spec](MODEL_SPECIFICATION.md#types)) together in a single fieldset
 
 ### getTypes(options)

--- a/packages/tc-schema-sdk/data-accessors/__tests__/type.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/type.spec.js
@@ -89,6 +89,27 @@ describe('get-type', () => {
 		});
 	});
 
+	it('can exclude meta properties', () => {
+		const metaPropertyName = metaProperties.map(property => property.name);
+		const type = typeFromRawData(
+			{
+				name: 'Type1',
+				description: 'I am Type1',
+				properties: {
+					property1: {
+						type: 'String',
+					},
+				},
+			},
+			{ options: { includeMetaFields: false } },
+		);
+
+		expect(type).toHaveProperty('properties');
+		metaPropertyName.forEach(propertyName => {
+			expect(type.properties).not.toHaveProperty(propertyName);
+		});
+	});
+
 	it('returns a type property to alias the name field', async () => {
 		const type = typeFromRawData({
 			name: 'Type1',
@@ -177,27 +198,35 @@ describe('get-type', () => {
 		expect(validator.test('AB')).toBe(true);
 	});
 
-	it('it returns read-only properties', async () => {
+	it('includes synthetic properties by default', () => {
 		const type = typeFromRawData({
 			name: 'Type1',
 			properties: {
-				primitiveProp: {
-					type: 'Word',
-					autoPopulated: true,
-				},
-				paragraphProp: {
-					type: 'Paragraph',
-					autoPopulated: false,
-				},
-				enumProp: {
-					type: 'SomeEnum',
+				syntheticProp: {
+					type: 'Type1',
+					cypher: 'MATCH blah',
 				},
 			},
 		});
 
-		expect(type.properties.primitiveProp.autoPopulated).toBe(true);
-		expect(type.properties.paragraphProp.autoPopulated).toBe(false);
-		expect(type.properties.enumProp.autoPopulated).toBeFalsy();
+		expect(type.properties).toHaveProperty('syntheticProp');
+	});
+
+	it('can exclude synthetic properties', () => {
+		const type = typeFromRawData(
+			{
+				name: 'Type1',
+				properties: {
+					syntheticProp: {
+						type: 'Type1',
+						cypher: 'MATCH blah',
+					},
+				},
+			},
+			{ options: { includeSyntheticFields: false } },
+		);
+
+		expect(type.properties).not.toHaveProperty('syntheticProp');
 	});
 
 	it('groups properties by fieldset', () => {

--- a/packages/tc-schema-sdk/data-accessors/type.js
+++ b/packages/tc-schema-sdk/data-accessors/type.js
@@ -175,16 +175,25 @@ const createPropertiesWithRelationships = function({
 	);
 };
 
+const removeSyntheticProperties = properties => {
+	Object.entries(properties).forEach(([name, { cypher }]) => {
+		if (cypher) {
+			delete properties[name];
+		}
+	});
+};
+
 const cacheKeyGenerator = (
 	typeName,
 	{
 		withRelationships = true,
 		groupProperties = false,
 		includeMetaFields = false,
+		includeSyntheticFields = true,
 		useMinimumViableRecord = false,
 	} = {},
 ) =>
-	`types:${typeName}:${withRelationships}:${groupProperties}:${includeMetaFields}:${useMinimumViableRecord}`;
+	`types:${typeName}:${withRelationships}:${groupProperties}:${includeMetaFields}:${includeSyntheticFields}:${useMinimumViableRecord}`;
 
 const getType = function(
 	typeName,
@@ -192,6 +201,7 @@ const getType = function(
 		withRelationships = true,
 		groupProperties = false,
 		includeMetaFields = false,
+		includeSyntheticFields = true,
 		useMinimumViableRecord = false,
 	} = {},
 ) {
@@ -218,6 +228,11 @@ const getType = function(
 	}
 
 	let properties = { ...typeSchema.properties };
+
+	if (!includeSyntheticFields) {
+		removeSyntheticProperties(properties);
+	}
+
 	const richRelationshipTypes = this.rawData.getRelationshipTypes();
 
 	const relationshipGetter = propName =>
@@ -241,6 +256,7 @@ const getType = function(
 	if (includeMetaFields) {
 		properties = assignMetaProperties(properties);
 	}
+
 	properties = transformPrimitiveTypes(properties, this.getStringValidator);
 
 	if (groupProperties) {

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -175,37 +175,42 @@ const propertyTestSuite = ({ typeName, properties, fieldsets }) => {
 					'RELATIONSHIP_NAME',
 				);
 				describe('relationship property', () => {
-					it('must specify underlying relationship', () => {
-						expect(config.relationship).toMatch(RELATIONSHIP_NAME);
-					});
-					it('must specify direction', () => {
-						expect(config.direction).toMatch(/^incoming|outgoing$/);
-					});
-					it('may be hidden', () => {
-						if (config.hidden) {
-							expect(config.hidden).toBe(true);
-						}
-					});
+					if (config.cypher) {
+						it('cypher statement is a string', () => {
+							expect(typeof config.cypher).toBe('string');
+						});
+					} else {
+						it('must specify underlying relationship', () => {
+							expect(config.relationship).toMatch(
+								RELATIONSHIP_NAME,
+							);
+						});
+						it('must specify direction', () => {
+							expect(config.direction).toMatch(
+								/^incoming|outgoing$/,
+							);
+						});
+						it('may be hidden', () => {
+							if (config.hidden) {
+								expect(config.hidden).toBe(true);
+							}
+						});
+						it('is defined at both ends', () => {
+							expect(
+								getTwinnedRelationship(
+									typeName,
+									config.type,
+									config.relationship,
+									config.direction,
+								),
+							).toBeDefined();
+						});
+					}
 
 					it('may have many', () => {
 						if (config.hasMany) {
 							expect(config.hasMany).toBe(true);
 						}
-					});
-					it('may have cypher', () => {
-						if (config.cypher) {
-							expect(typeof config.cypher).toBe('string');
-						}
-					});
-					it('is defined at both ends', () => {
-						expect(
-							getTwinnedRelationship(
-								typeName,
-								config.type,
-								config.relationship,
-								config.direction,
-							),
-						).toBeDefined();
 					});
 				});
 			} else {

--- a/packages/tc-ui/src/lib/get-schema-subset.js
+++ b/packages/tc-ui/src/lib/get-schema-subset.js
@@ -8,6 +8,7 @@ const getSchemaSubset = (event, type, isCreate = false) => {
 			schema: getType(type, {
 				groupProperties: true,
 				includeMetaFields: false,
+				includeSyntheticFields: false,
 				useMinimumViableRecord: isCreate,
 			}),
 			isSubset: false,
@@ -18,7 +19,9 @@ const getSchemaSubset = (event, type, isCreate = false) => {
 	const fullSchema = getType(type, {
 		groupProperties: false,
 		includeMetaFields: false,
+		includeSyntheticFields: false,
 	});
+
 	const propertyKeys = properties.split(',');
 	return {
 		schema: {

--- a/packages/tc-ui/src/lib/mappers/graphql-query-builder.js
+++ b/packages/tc-ui/src/lib/mappers/graphql-query-builder.js
@@ -7,7 +7,10 @@ const graphqlQueryBuilder = (type, assignComponent) => `
 	query getStuff($itemId: String!) {
     ${type} (code: $itemId) {
     ${Object.entries(
-		schema.getType(type, { includeMetaFields: true }).properties,
+		schema.getType(type, {
+			includeMetaFields: true,
+			includeSyntheticFields: false,
+		}).properties,
 	)
 		.filter(([, { deprecationReason }]) => !deprecationReason)
 		.map(([propName, propDef]) =>


### PR DESCRIPTION
## Why?

The UI breaks when properties make use of the powerful @cypher directive. There's another PR to sketch out what being able to display these properties in the UI might look like https://github.com/Financial-Times/treecreeper/pull/256...

But I realised that is quite a big job, and using @cypher is useful now (in particular for distilling risk blast radiuses down into summaries, or extracting other useful summaries from the new more ophisticated modelling we're doing of prosucts, capabilities, Fastly, Hosts etc).

So this PR implements the relatively small chaneg of suppressing any attempt to render these fields in the admin UI, saving them for the GraphQL api alone. This means we can define them and explore using them, then take on the UI job as and when it feels useful to do so

## What?

- Adds a new `includeSyntheticFields` property to `getType`, defaulting to `true` (for backwards compat)
- This is then used when types are accessed within tc-ui
- updates some schema validation and schema sdk tests

## TODO

API validation needs updating so that its' impossible to accidentally write a cypher property - this should error informatively:

```bash
curl -X PATCH 'http://local.in.ft.com:8888/api/rest/MainType/bob?upsert=true&relationshipAction=merge' --data '{"cypherThing": "tony"}' -H 'client-id: rhys' -X 'content-type: application/json'
```

*update - there is a test for this and it _should_ 400, but not doing so for some reason*
*update 2 - false alarm, the api call was malformed. The validation is good as it is*