### PR TITLE
reduce size of documents once at the root level

### DIFF
--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -5,7 +5,14 @@ const { Concept, Fieldset } = require('../../lib/components/structure');
 const { getValue } = require('../../lib/mappers/get-value');
 const { SaveButton, CancelButton } = require('../../lib/components/buttons');
 
-const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
+const PropertyInputs = ({
+	fields,
+	data,
+	type,
+	assignComponent,
+	hasError,
+	clientSideRecord,
+}) => {
 	const propertyDefinitionsArray = Object.entries(fields);
 
 	const fieldsToLock = data._lockedFields
@@ -30,26 +37,6 @@ const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 			const itemValue = propDef.isRelationship
 				? data[`${propertyName}_rel`] || data[propertyName]
 				: data[propertyName];
-
-			/**
-			 * Sending the entire record to the client multiple times can increase the payload immensely
-			 * However some components rely on this (eg "decommissioned" functionality)
-			 * As a workaround for now, truncate long text fields
-			 * TODO: think of a better way to be selective about what we send
-			 */
-			const clientSideRecord = { ...data };
-			propertyDefinitionsArray
-				// HACK Document has a weird status in that it's not part of the tc primitive types
-				// and yet we have an entire sublibrary - tc-api-document-store - built around the
-				// notion of having documents. So it feels a litte dirty, but probably ok, to use
-				// it here
-				// We check for fields
-				.filter(
-					([key]) => 'key' in data && fields[key].type === 'Document',
-				)
-				.forEach(([key]) => {
-					clientSideRecord[key] = `${data[key].substring(0, 24)}…`;
-				});
 
 			const viewModel = {
 				hasError,
@@ -89,6 +76,7 @@ const EditForm = props => {
 		code,
 		querystring,
 		assignComponent,
+		clientSideRecord,
 	} = props;
 
 	return (
@@ -152,6 +140,7 @@ const EditForm = props => {
 									fields={properties}
 									data={data}
 									type={type}
+									clientSideRecord={clientSideRecord}
 									assignComponent={assignComponent}
 								/>
 							</Fieldset>


### PR DESCRIPTION
## Why?

Still a bug where biz ops pages with large images embedded bust the lambda payload limit despite trimming strings

## What?
Because the form is broken into fieldsets each fieldset was only shrinking down the size of the one or tow fields that appeared in it. This PR does it once a t the root level and passes the smaller object down the tree