### PR TITLE
only send json copy of record once to the browser

### DIFF
--- a/packages/tc-ui/src/pages/edit/browser.js
+++ b/packages/tc-ui/src/pages/edit/browser.js
@@ -18,7 +18,7 @@ const initDocumentEditors = () => {
 	);
 };
 
-const initRelationshipSelectors = (entireRecord) => {
+const initRelationshipSelectors = entireRecord => {
 	[
 		...document.querySelectorAll(
 			'[data-component="relationship-picker"]:not([data-disabled])',
@@ -105,7 +105,9 @@ Type SAVE INCOMPLETE RECORD below to proceed, or click cancel to return to the f
 
 module.exports.init = async () => {
 	await initSchema();
-	const entireRecord = JSON.parse(document.querySelector("#tc-form").dataset.tcEntireRecord);
+	const entireRecord = JSON.parse(
+		document.querySelector('#tc-form').dataset.tcEntireRecord,
+	);
 	initDocumentEditors();
 	initRelationshipSelectors(entireRecord);
 	preventBadSubmission();

--- a/packages/tc-ui/src/pages/edit/browser.js
+++ b/packages/tc-ui/src/pages/edit/browser.js
@@ -18,12 +18,12 @@ const initDocumentEditors = () => {
 	);
 };
 
-const initRelationshipSelectors = () => {
+const initRelationshipSelectors = (entireRecord) => {
 	[
 		...document.querySelectorAll(
 			'[data-component="relationship-picker"]:not([data-disabled])',
 		),
-	].forEach(attachRelationshipPicker);
+	].forEach(container => attachRelationshipPicker(container, entireRecord));
 };
 
 // TODO - the relationship editors should expose their bad state in some way
@@ -105,8 +105,9 @@ Type SAVE INCOMPLETE RECORD below to proceed, or click cancel to return to the f
 
 module.exports.init = async () => {
 	await initSchema();
+	const entireRecord = JSON.parse(document.querySelector("#tc-form").dataset.tcEntireRecord);
 	initDocumentEditors();
-	initRelationshipSelectors();
+	initRelationshipSelectors(entireRecord);
 	preventBadSubmission();
 	preventIncompleteSubmission();
 };

--- a/packages/tc-ui/src/pages/edit/handler.js
+++ b/packages/tc-ui/src/pages/edit/handler.js
@@ -2,6 +2,9 @@ const { getType } = require('@financial-times/tc-schema-sdk');
 const httpError = require('http-errors');
 const template = require('./template');
 
+
+// hack once we're out of lambda and don't need to care about large payloads
+// any more we can remove this
 const getClientSideRecord = (type, formData) => {
 	const { properties } = getType(type);
 	/**

--- a/packages/tc-ui/src/pages/edit/handler.js
+++ b/packages/tc-ui/src/pages/edit/handler.js
@@ -1,33 +1,5 @@
-const { getType } = require('@financial-times/tc-schema-sdk');
 const httpError = require('http-errors');
 const template = require('./template');
-
-
-// hack once we're out of lambda and don't need to care about large payloads
-// any more we can remove this
-const getClientSideRecord = (type, formData) => {
-	const { properties } = getType(type);
-	/**
-	 * Sending the entire record to the client multiple times can increase the payload immensely
-	 * However some components rely on this (eg "decommissioned" functionality)
-	 * As a workaround for now, truncate long text fields
-	 * TODO: think of a better way to be selective about what we send
-	 */
-	const clientSideRecord = { ...formData };
-
-	Object.entries(properties)
-		// HACK Document has a weird status in that it's not part of the tc primitive types
-		// and yet we have an entire sublibrary - tc-api-document-store - built around the
-		// notion of having documents. So it feels a litte dirty, but probably ok, to use
-		// it here
-		// We check for fields
-		.filter(([key]) => formData[key] && properties[key].type === 'Document')
-		.forEach(([key]) => {
-			clientSideRecord[key] = `${formData[key].substring(0, 24)}…`;
-		});
-
-	return clientSideRecord;
-};
 
 const getEditHandler = ({
 	getApiClient,
@@ -58,7 +30,6 @@ const getEditHandler = ({
 
 		const templateData = {
 			...getSchemaSubset(event, type, isCreate),
-			clientSideRecord: getClientSideRecord(type, formData),
 			data: formData,
 			type,
 			code,

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -41,7 +41,6 @@ const PropertyInputs = ({
 			const viewModel = {
 				hasError,
 				parentCode: data.code,
-				entireRecord: clientSideRecord,
 				propertyName,
 				value: getValue(propDef, itemValue),
 				dataType: propDef.type,
@@ -58,7 +57,7 @@ const PropertyInputs = ({
 					<EditComponent {...viewModel} />
 					{AdditionalEditComponent ? (
 						<div className="additional-edit-component-hydration-container">
-							<AdditionalEditComponent {...viewModel} />
+							<AdditionalEditComponent {...viewModel} entireRecord={clientSideRecord}/>
 						</div>
 					) : null}
 				</div>
@@ -83,6 +82,7 @@ const EditForm = props => {
 		<>
 			<div className="o-layout__sidebar" />
 			<form
+				id="tc-form"
 				className="o-layout__main o-forms"
 				action={
 					isEdit
@@ -92,6 +92,7 @@ const EditForm = props => {
 				method="POST"
 				autoComplete="off"
 				data-tc-page-type={props.pageType}
+				data-tc-entire-record={JSON.stringify(clientSideRecord)}
 			>
 				<div className="o-layout__main__full-span">
 					{/* note we use code || data.code so that, when creating and there is no

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -5,14 +5,7 @@ const { Concept, Fieldset } = require('../../lib/components/structure');
 const { getValue } = require('../../lib/mappers/get-value');
 const { SaveButton, CancelButton } = require('../../lib/components/buttons');
 
-const PropertyInputs = ({
-	fields,
-	data,
-	type,
-	assignComponent,
-	hasError,
-	clientSideRecord,
-}) => {
+const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 	const propertyDefinitionsArray = Object.entries(fields);
 
 	const fieldsToLock = data._lockedFields
@@ -57,7 +50,10 @@ const PropertyInputs = ({
 					<EditComponent {...viewModel} />
 					{AdditionalEditComponent ? (
 						<div className="additional-edit-component-hydration-container">
-							<AdditionalEditComponent {...viewModel} entireRecord={clientSideRecord}/>
+							<AdditionalEditComponent
+								{...viewModel}
+								entireRecord={data}
+							/>
 						</div>
 					) : null}
 				</div>
@@ -75,7 +71,6 @@ const EditForm = props => {
 		code,
 		querystring,
 		assignComponent,
-		clientSideRecord,
 	} = props;
 
 	return (
@@ -92,7 +87,7 @@ const EditForm = props => {
 				method="POST"
 				autoComplete="off"
 				data-tc-page-type={props.pageType}
-				data-tc-entire-record={JSON.stringify(clientSideRecord)}
+				data-tc-entire-record={JSON.stringify(data)}
 			>
 				<div className="o-layout__main__full-span">
 					{/* note we use code || data.code so that, when creating and there is no
@@ -141,7 +136,6 @@ const EditForm = props => {
 									fields={properties}
 									data={data}
 									type={type}
-									clientSideRecord={clientSideRecord}
 									assignComponent={assignComponent}
 								/>
 							</Fieldset>

--- a/packages/tc-ui/src/primitives/relationship/browser.jsx
+++ b/packages/tc-ui/src/primitives/relationship/browser.jsx
@@ -1,12 +1,12 @@
 require('./main.css');
 const React = require('react');
-const { hydrate } = require('react-dom');
+const { render } = require('react-dom');
 const { RelationshipPicker } = require('./lib/relationship-picker');
 
 module.exports = {
-	withEditComponent: container =>
-		hydrate(
-			<RelationshipPicker {...JSON.parse(container.dataset.props)} />,
+	withEditComponent: (container, entireRecord) =>
+		render(
+			<RelationshipPicker {...JSON.parse(container.dataset.props)} entireRecord={entireRecord} />,
 			container.parentNode,
 		),
 };

--- a/packages/tc-ui/src/primitives/relationship/browser.jsx
+++ b/packages/tc-ui/src/primitives/relationship/browser.jsx
@@ -6,7 +6,10 @@ const { RelationshipPicker } = require('./lib/relationship-picker');
 module.exports = {
 	withEditComponent: (container, entireRecord) =>
 		render(
-			<RelationshipPicker {...JSON.parse(container.dataset.props)} entireRecord={entireRecord} />,
+			<RelationshipPicker
+				{...JSON.parse(container.dataset.props)}
+				entireRecord={entireRecord}
+			/>,
 			container.parentNode,
 		),
 };


### PR DESCRIPTION
## Why?

Fixes #267 - this is having user impact surprisingly quickly

## What?

- Sets the entire record as a property of the entire form
- Passes that in to the component on the client side (need to use render rather than hydrate as the component now has extra props on the client side so hydrate moans about the data not matching)
- Stops passing entire record into individual primitive components on the server side (aside from `AdditionalEditComponent` which the user may set - it'd be a breaking change to remove from there)
- stop creating a truncated version of the record to send to the client - now it's only a single copy we will not breach the payload limit