### PR TITLE
loosen tests to allow integer codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cypress/screenshots/
 cypress/videos/
 cypress/fixtures/
 dist/
+.env

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ run-test-db:
   mkdir -p neo4j; \
   wget -q dist.neo4j.org/neo4j-community-$(NEO4J_VERSION)-unix.tar.gz; \
   tar -xzf neo4j-community-$(NEO4J_VERSION)-unix.tar.gz -C neo4j --strip-components 1; \
-  sed -i "s|# dbms.security.auth_enabled=false|dbms.security.auth_enabled=false|g" neo4j/conf/neo4j.conf;\
+  echo "dbms.security.auth_enabled=false" >> neo4j/conf/neo4j.conf;\
   ./scripts/neo4j-plugins; \
 	dbms_memory_heap_initial_size="1024m" dbms_memory_heap_max_size="1024m" neo4j/bin/neo4j start; \
   ./scripts/neo4j-wait-for-start;

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ run-test-db:
   mkdir -p neo4j; \
   wget -q dist.neo4j.org/neo4j-community-$(NEO4J_VERSION)-unix.tar.gz; \
   tar -xzf neo4j-community-$(NEO4J_VERSION)-unix.tar.gz -C neo4j --strip-components 1; \
-  sed -i "s|#dbms.security.auth_enabled=false|dbms.security.auth_enabled=false|g" neo4j/conf/neo4j.conf;\
+  sed -i "s|# dbms.security.auth_enabled=false|dbms.security.auth_enabled=false|g" neo4j/conf/neo4j.conf;\
   ./scripts/neo4j-plugins; \
 	dbms_memory_heap_initial_size="1024m" dbms_memory_heap_max_size="1024m" neo4j/bin/neo4j start; \
   ./scripts/neo4j-wait-for-start;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "http-errors": "^1.7.3",
     "lodash": "^4.17.18",
     "module-alias": "^2.2.2",
-    "neo4j-driver": "^1.7.6",
+    "neo4j-driver": "1.7.6",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/packages/tc-api-db-manager/package.json
+++ b/packages/tc-api-db-manager/package.json
@@ -7,7 +7,7 @@
     "@financial-times/n-logger": "^6.1.0",
     "@financial-times/tc-api-express-logger": "file:../tc-api-express-logger",
     "@financial-times/tc-schema-sdk": "file:../tc-schema-sdk",
-    "neo4j-driver": "^1.7.6",
+    "neo4j-driver": "1.7.6",
     "next-metrics": "^3.1.22"
   },
   "repository": {

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -379,9 +379,20 @@ const typeTestSuite = type => {
 				expect(type.properties.code.canIdentify).toEqual(true);
 			});
 
-			it('has a code that respects a pattern', () => {
-				expect(type.properties.code.pattern).toBeDefined();
+			it('has a string or integer code', () => {
+				expect(['String', 'Int']).toContain(primitiveTypesMap[type.properties.code.type]);
 			});
+
+			// any string ids (as opposed to integers) should have patterns defined
+			if (primitiveTypesMap[type.properties.code.type] === "String") {
+				it('has a string code that respects a pattern', () => {
+					expect(type.properties.code.pattern).toBeDefined();
+				});
+			} else {
+				it('has an integer code that does not define a custom pattern', () => {
+					expect(type.properties.code.pattern).not.toBeDefined();
+				});
+			}
 
 			propertyTestSuite({
 				typeName: type.name,

--- a/packages/tc-schema-validator/tests/type-test-suite.js
+++ b/packages/tc-schema-validator/tests/type-test-suite.js
@@ -380,11 +380,13 @@ const typeTestSuite = type => {
 			});
 
 			it('has a string or integer code', () => {
-				expect(['String', 'Int']).toContain(primitiveTypesMap[type.properties.code.type]);
+				expect(['String', 'Int']).toContain(
+					primitiveTypesMap[type.properties.code.type],
+				);
 			});
 
 			// any string ids (as opposed to integers) should have patterns defined
-			if (primitiveTypesMap[type.properties.code.type] === "String") {
+			if (primitiveTypesMap[type.properties.code.type] === 'String') {
 				it('has a string code that respects a pattern', () => {
 					expect(type.properties.code.pattern).toBeDefined();
 				});


### PR DESCRIPTION
## Why?

Response bot uses incrementing integers as identifiers fro incidents. However, when importing data using `Int` as the type for the code of Incident records is not permitted, leading to some jhacks around adding a string pattern that won't be used, or using a String type and writing `"123"` rather than `123`

## What?
Changes the tests to be intelligent enough to have relaxed expectations around patterns if an Int type is used