### PR TITLE
Allow custom resolver to co-exist with document resolver

### DIFF
--- a/packages/tc-api-graphql/__tests__/graphql.spec.js
+++ b/packages/tc-api-graphql/__tests__/graphql.spec.js
@@ -318,6 +318,11 @@ describe('graphql', () => {
 						}),
 					},
 				},
+				documentStore: {
+					get: async (type, code) => ({
+						body: { someDocument: `document for ${code}` },
+					}),
+				},
 			});
 
 			updateGraphqlApiOnSchemaChange();
@@ -351,6 +356,35 @@ describe('graphql', () => {
 								someString: 'some string',
 								someFloat: 20.21,
 								someEnum: 'First',
+							},
+						},
+					},
+				});
+		});
+
+		it('Extended Resolver and document can co-exist on same type', async () => {
+			await createNode('MainType', {
+				code: mainCode,
+			});
+			return request(testApp)
+				.post('/graphql')
+				.send({
+					query: `{
+					MainType(filter: {code: "${mainCode}"}) {
+						code
+						someDocument
+						extended {
+							someString
+						}
+					}}`,
+				})
+				.expect(200, {
+					data: {
+						MainType: {
+							code: mainCode,
+							someDocument: `document for ${mainCode}`,
+							extended: {
+								someString: 'some string',
 							},
 						},
 					},

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -3,8 +3,8 @@ const { makeAugmentedSchema } = require('neo4j-graphql-js');
 const { applyMiddleware } = require('graphql-middleware');
 const { parse } = require('graphql');
 const { getGraphqlDefs, getTypes } = require('@financial-times/tc-schema-sdk');
+const merge = require('lodash.merge');
 const { middleware: requestTracer } = require('./request-tracer');
-const {merge} = require('lodash');
 
 const resolveDocumentProperty = async ({ code }, args, context, info) => {
 	if (!code) {

--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -4,6 +4,7 @@ const { applyMiddleware } = require('graphql-middleware');
 const { parse } = require('graphql');
 const { getGraphqlDefs, getTypes } = require('@financial-times/tc-schema-sdk');
 const { middleware: requestTracer } = require('./request-tracer');
+const {merge} = require('lodash');
 
 const resolveDocumentProperty = async ({ code }, args, context, info) => {
 	if (!code) {
@@ -48,7 +49,7 @@ const getAugmentedSchema = ({
 	}
 	if (Object.keys(extendedResolvers).length) {
 		// add custom resolvers
-		Object.assign(resolvers, { ...extendedResolvers });
+		merge(resolvers, { ...extendedResolvers });
 	}
 
 	// this should throw meaningfully if the defs are invalid;

--- a/packages/tc-api-graphql/package.json
+++ b/packages/tc-api-graphql/package.json
@@ -5,14 +5,15 @@
   "main": "index.js",
   "dependencies": {
     "@financial-times/n-logger": "^6.1.0",
-    "@financial-times/tc-schema-publisher": "file:../tc-schema-publisher",
-    "@financial-times/tc-api-express-logger": "file:../tc-api-express-logger",
-    "@financial-times/tc-schema-sdk": "file:../tc-schema-sdk",
     "@financial-times/tc-api-db-manager": "file:../tc-api-db-manager",
+    "@financial-times/tc-api-express-logger": "file:../tc-api-express-logger",
+    "@financial-times/tc-schema-publisher": "file:../tc-schema-publisher",
+    "@financial-times/tc-schema-sdk": "file:../tc-schema-sdk",
     "apollo-server-express": "^2.9.7",
     "dataloader": "^1.4.0",
     "graphql": "^14.5.8",
     "graphql-middleware": "^4.0.2",
+    "lodash.merge": "^4.6.2",
     "neo4j-graphql-js": "financial-times/neo4j-graphql-js#non-leaky-reflexive-relationships"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why?

Currently if you add a customer resolve to a Type which has any document fields, the document resolvers get removed.

## What?

Using lodash's merge function to deep merge the resolvers objects, rather than the shallow Object.assign.  This enables both sets of resolvers to exist side-by-side.
