### PR TITLE
Related dates

### DIFF
--- a/packages/tc-ui/src/primitives/relationship/server.jsx
+++ b/packages/tc-ui/src/primitives/relationship/server.jsx
@@ -75,12 +75,17 @@ module.exports = {
 
 		Object.entries(typeDef.properties)
 			.filter(([, { useInSummary }]) => useInSummary)
-			.forEach(([name]) => props.add(name));
+			.forEach(([name, { type: fieldType }]) =>
+				props.add(
+					['DateTime', 'Date', 'Time'].includes(fieldType)
+						? `${name} { formatted }`
+						: name,
+				),
+			);
 		const nodeProps = [...props].join(' ');
 		const relationshipProps = [...new Set(Object.keys(properties))].join(
 			' ',
 		);
-
 		return `${propName}_rel {${type} {${nodeProps}} ${relationshipProps}}`;
 	},
 };


### PR DESCRIPTION
## Why?

For the first time we have examples of records that have a temporal field in heir summaries (Incidents with their start dates). The UI breaks for records related to these records because the query to generate the relationships is constructed from invalid fragments

## What?
For temporal types, request `{formatted}`