### PR TITLE
🧙 Upgrade rel-engage to 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   ft-snyk-orb: financial-times/ft-snyk-orb@0
 
 references:
-
   default_container_config: &default_container_config
     docker:
       # need -browsers as it bundles selenium, which bundles java, which we need
@@ -15,13 +14,11 @@ references:
           TERM: xterm
 
     environment:
-      NEO4J_VERSION: "3.5.0"
+      NEO4J_VERSION: '3.5.0'
 
-  workspace_root: &workspace_root
-    ~/
+  workspace_root: &workspace_root ~/
 
-  cache_key: &cache_key
-    cache-v5-{{ .Branch }}-{{ checksum "./package.json" }}
+  cache_key: &cache_key cache-v5-{{ .Branch }}-{{ checksum "./package.json" }}
 
   attach_workspace: &attach_workspace
     attach_workspace:
@@ -105,7 +102,7 @@ jobs:
           name: Run tests
           command: make init-db test
           environment:
-            JEST_JUNIT_OUTPUT: "junit/test-results.xml"
+            JEST_JUNIT_OUTPUT: 'junit/test-results.xml'
       - store_test_results:
           path: junit
 

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-	"baseUrl": "http://localhost:8888",
-	"integrationFolder": "./packages/tc-ui/src/",
-	"testFiles": "**/*.cyp.js"
+  "baseUrl": "http://localhost:8888",
+  "integrationFolder": "./packages/tc-ui/src/",
+  "testFiles": "**/*.cyp.js"
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,12 +8,10 @@ services:
       - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes
       - NEO4J_db_temporal_timezone=Z
     ports:
-      - "7474:7474"
-      - "7473:7473"
-      - "7687:7687"
+      - '7474:7474'
+      - '7473:7473'
+      - '7687:7687'
     volumes:
       - ./neo4j/data:/data
       - ./neo4j/plugins:/plugins
       - ./neo4j/logs:/logs
-
-

--- a/example-schema/types/ChildType.yaml
+++ b/example-schema/types/ChildType.yaml
@@ -1,7 +1,7 @@
 name: ChildType
 description: Description of ChildType.
 moreInformation: |
-    More information for ChildType
+  More information for ChildType
 properties:
   code:
     type: Code

--- a/example-schema/types/MVRType.yaml
+++ b/example-schema/types/MVRType.yaml
@@ -1,11 +1,11 @@
 name: MVRType
 description: Description of MVRType.
 moreInformation: |
-    More information for MVRType
+  More information for MVRType
 minimumViableRecord:
-    - code
-    - children
-    - someString
+  - code
+  - children
+  - someString
 properties:
   code:
     type: Code
@@ -26,4 +26,3 @@ properties:
     description: Word description.
     label: Word label
     useInSummary: true
-

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -1,7 +1,7 @@
 name: MainType
 description: Description of MainType.
 moreInformation: |
-    More information for MainType
+  More information for MainType
 properties:
   code:
     type: Code
@@ -149,5 +149,5 @@ properties:
     label: Cypher haha
     description: Cypher hahahahaha.
     type: ChildType
-    cypher: "MATCH (this)-[:HAS_CHILD]->(c) RETURN c"
+    cypher: 'MATCH (this)-[:HAS_CHILD]->(c) RETURN c'
     hasMany: true

--- a/example-schema/types/ParentType.yaml
+++ b/example-schema/types/ParentType.yaml
@@ -1,7 +1,7 @@
 name: ParentType
 description: Description of ParentType.
 moreInformation: |
-    More information for ParentType
+  More information for ParentType
 properties:
   code:
     type: Code

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.7.0",
     "@financial-times/athloi": "^1.0.0-beta.29",
-    "@financial-times/rel-engage": "^7.4.3",
+    "@financial-times/rel-engage": "^8.0.1",
     "@financial-times/tc-api-graphql": "file:./packages/tc-api-graphql",
     "aws-sdk": "^2.611.0",
     "babel-loader": "^8.0.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express": "^4.17.1",
     "graphql-playground-middleware-express": "^1.7.14",
     "http-errors": "^1.7.3",
-    "lodash": "^4.17.18",
+    "lodash": "^4.17.20",
     "module-alias": "^2.2.2",
     "neo4j-driver": "^1.7.7",
     "node-fetch": "^2.6.0",

--- a/packages/tc-api-express/__tests__/rest-test-suite.js
+++ b/packages/tc-api-express/__tests__/rest-test-suite.js
@@ -66,9 +66,7 @@ const testSuite = (method, goodStatus) => {
 
 		describe('client headers', () => {
 			it(`no client-id or client-user-id returns 400`, async () => {
-				return request(app)
-					[getRequestMethod()](restUrl)
-					.expect(400);
+				return request(app)[getRequestMethod()](restUrl).expect(400);
 			});
 
 			it(`client-id but no client-user-id returns ${goodStatus}`, async () => {

--- a/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
@@ -530,9 +530,7 @@ describe('rest document store integration', () => {
 				children: expect.any(Array),
 			});
 
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.hasRels(0);
+			await neo4jTest('MainType', mainCode).exists().hasRels(0);
 		});
 	});
 });

--- a/packages/tc-api-rest-handlers/__tests__/global-lock.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/global-lock.spec.js
@@ -32,11 +32,9 @@ describe('global field locking', () => {
 			expect(body).not.toMatchObject({
 				_lockedFields: expect.any(String),
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match({
-					lockedField: 'some string',
-				});
+			await neo4jTest('MainType', mainCode).exists().match({
+				lockedField: 'some string',
+			});
 		});
 		it('fails to create if using wrong client', async () => {
 			await expect(
@@ -71,11 +69,9 @@ describe('global field locking', () => {
 			expect(body).not.toMatchObject({
 				_lockedFields: expect.any(String),
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match({
-					lockedField: 'some string',
-				});
+			await neo4jTest('MainType', mainCode).exists().match({
+				lockedField: 'some string',
+			});
 		});
 		it('fails to patch if using wrong client', async () => {
 			await createNode('MainType', { code: mainCode });
@@ -90,11 +86,9 @@ describe('global field locking', () => {
 				message:
 					'Cannot write lockedField on MainType global-lock-main - property can only be edited by client global-lock-client',
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.notMatch({
-					lockedField: 'some string',
-				});
+			await neo4jTest('MainType', mainCode).exists().notMatch({
+				lockedField: 'some string',
+			});
 		});
 	});
 });

--- a/packages/tc-api-rest-handlers/__tests__/patch-create.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-create.spec.js
@@ -61,9 +61,7 @@ describe('rest PATCH create', () => {
 
 			expect(status).toBe(201);
 			expect(body).toMatchObject(meta.create);
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match(meta.create);
+			await neo4jTest('MainType', mainCode).exists().match(meta.create);
 		});
 		it('sets array data', async () => {
 			const { body, status } = await basicHandler({
@@ -149,12 +147,10 @@ describe('rest PATCH create', () => {
 				code: mainCode,
 				someDate: date,
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match({
-					code: mainCode,
-					someDate: date,
-				});
+			await neo4jTest('MainType', mainCode).exists().match({
+				code: mainCode,
+				someDate: date,
+			});
 		});
 
 		const neo4jTimePrecision = timestamp =>

--- a/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-relationship-create.spec.js
@@ -1141,9 +1141,7 @@ describe('rest PATCH relationship create', () => {
 					'Invalid property `notInSchema` on type `CuriousChild`.',
 			});
 
-			await neo4jTest('MainType', mainCode)
-				.match(meta.default)
-				.noRels();
+			await neo4jTest('MainType', mainCode).match(meta.default).noRels();
 		});
 
 		it('create node related to nodes with strange codes', async () => {

--- a/packages/tc-api-rest-handlers/__tests__/patch-update.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-update.spec.js
@@ -73,9 +73,7 @@ describe('rest PATCH update', () => {
 
 			expect(status).toBe(200);
 			expect(body).toMatchObject(meta.update);
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match(meta.update);
+			await neo4jTest('MainType', mainCode).exists().match(meta.update);
 		});
 		it('deletes a property as an update', async () => {
 			await createMainNode({
@@ -125,11 +123,9 @@ describe('rest PATCH update', () => {
 						code: mainCode,
 						someDate: date,
 					});
-					await neo4jTest('MainType', mainCode)
-						.exists()
-						.match({
-							someDate: date,
-						});
+					await neo4jTest('MainType', mainCode).exists().match({
+						someDate: date,
+					});
 				});
 				it('updates existing Date', async () => {
 					await createMainNode({
@@ -146,11 +142,9 @@ describe('rest PATCH update', () => {
 					expect(body).toMatchObject({
 						someDate: date,
 					});
-					await neo4jTest('MainType', mainCode)
-						.exists()
-						.match({
-							someDate: date,
-						});
+					await neo4jTest('MainType', mainCode).exists().match({
+						someDate: date,
+					});
 				});
 				it("doesn't update when effectively the same Date", async () => {
 					const date = '2019-01-09';
@@ -332,12 +326,10 @@ describe('rest PATCH update', () => {
 				someBoolean: false,
 				someInteger: 0,
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match({
-					someBoolean: false,
-					someInteger: 0,
-				});
+			await neo4jTest('MainType', mainCode).exists().match({
+				someBoolean: false,
+				someInteger: 0,
+			});
 		});
 		it('no clientId, deletes the _updatedByClient property', async () => {
 			await createMainNode();

--- a/packages/tc-api-rest-handlers/__tests__/post.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/post.spec.js
@@ -65,9 +65,7 @@ describe('rest POST', () => {
 
 			expect(status).toBe(200);
 			expect(body).toMatchObject(meta.create);
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match(meta.create);
+			await neo4jTest('MainType', mainCode).exists().match(meta.create);
 		});
 
 		it('sets array data', async () => {
@@ -115,12 +113,10 @@ describe('rest POST', () => {
 				code: mainCode,
 				someDate: date,
 			});
-			await neo4jTest('MainType', mainCode)
-				.exists()
-				.match({
-					code: mainCode,
-					someDate: date,
-				});
+			await neo4jTest('MainType', mainCode).exists().match({
+				code: mainCode,
+				someDate: date,
+			});
 		});
 		const neo4jTimePrecision = timestamp =>
 			timestamp.replace('Z', '000000Z');

--- a/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
+++ b/packages/tc-markdown-parser/__tests__/nested-property-value.spec.js
@@ -13,11 +13,7 @@ const parser = getParser({
 
 // The weird string concatenation in the markdown fixture is so that
 // dev tooling doesn't tidy up the 'extraneous' whitespace
-const addLineBreaks = str =>
-	str
-		.replace(/\t+/g, '\t')
-		.split('\n')
-		.join('  \n');
+const addLineBreaks = str => str.replace(/\t+/g, '\t').split('\n').join('  \n');
 
 describe('nested property definition tests', () => {
 	describe('single relationship case - hasMany: false', () => {

--- a/packages/tc-markdown-parser/lib/markdown-parser.js
+++ b/packages/tc-markdown-parser/lib/markdown-parser.js
@@ -12,7 +12,7 @@ const stringifyBoast = require('./unist-stringifiers/stringify-boast');
 const setNestedMultilineProperties = require('./tree-mutators/set-nested-multiline-properties');
 
 /* @param schema: Treecreeper schema singleton */
-const unifiedProcessor = function({
+const unifiedProcessor = function ({
 	type,
 	titleFieldName = 'name',
 	descriptionFieldName = 'description',
@@ -78,11 +78,11 @@ const getParser = ({
 		blacklistPropertyNames,
 	});
 
-	markdownParser.createStream = async function() {
+	markdownParser.createStream = async function () {
 		return createStream(await this());
 	};
 
-	markdownParser.parseMarkdownString = async function(markdownString) {
+	markdownParser.parseMarkdownString = async function (markdownString) {
 		const processor = await this();
 		const vfile = await processor.process(markdownString);
 		try {

--- a/packages/tc-markdown-parser/lib/normalize-property-key.js
+++ b/packages/tc-markdown-parser/lib/normalize-property-key.js
@@ -3,8 +3,5 @@
 	string with no spaces so they can be matched against one another in styles
 */
 module.exports = function normalizePropertyKey(key = '') {
-	return key
-		.normalize()
-		.toLowerCase()
-		.replace(/\s+/g, '');
+	return key.normalize().toLowerCase().replace(/\s+/g, '');
 };

--- a/packages/tc-schema-publisher/index.js
+++ b/packages/tc-schema-publisher/index.js
@@ -7,10 +7,7 @@ const s3Client = new AWS.S3({ region: 'eu-west-1' });
 
 const getVersion = schemaObject => {
 	const asString = JSON.stringify(schemaObject, null, 2);
-	return crypto
-		.createHash('md5')
-		.update(asString)
-		.digest('hex');
+	return crypto.createHash('md5').update(asString).digest('hex');
 };
 
 const sendSchemaToS3 = async (

--- a/packages/tc-schema-sdk/data-accessors/relationship-type.js
+++ b/packages/tc-schema-sdk/data-accessors/relationship-type.js
@@ -121,7 +121,7 @@ const cacheKeyGenerator = (
 	{ includeMetaFields = false } = {},
 ) => `relationships:${rootType}:${propertyName}:${includeMetaFields}`;
 
-const getRelationshipType = function(
+const getRelationshipType = function (
 	rootType,
 	propertyName,
 	{ includeMetaFields = false } = {},

--- a/packages/tc-schema-sdk/data-accessors/type.js
+++ b/packages/tc-schema-sdk/data-accessors/type.js
@@ -112,7 +112,7 @@ const findCardinality = (direction, relationshipType) =>
 		? relationshipType.to.hasMany
 		: relationshipType.from.hasMany;
 
-const createPropertiesWithRelationships = function({
+const createPropertiesWithRelationships = function ({
 	richRelationshipTypes,
 	properties,
 	relationshipGetter,
@@ -195,7 +195,7 @@ const cacheKeyGenerator = (
 ) =>
 	`types:${typeName}:${withRelationships}:${groupProperties}:${includeMetaFields}:${includeSyntheticFields}:${useMinimumViableRecord}`;
 
-const getType = function(
+const getType = function (
 	typeName,
 	{
 		withRelationships = true,

--- a/packages/tc-schema-sdk/lib/utils.js
+++ b/packages/tc-schema-sdk/lib/utils.js
@@ -1,7 +1,7 @@
 const invertDirection = direction =>
 	direction === 'incoming' ? 'outgoing' : 'incoming';
 
-const findPropertyNamesFromPropertyDef = function({
+const findPropertyNamesFromPropertyDef = function ({
 	rootType,
 	direction,
 	relationship,
@@ -18,7 +18,7 @@ const findPropertyNamesFromPropertyDef = function({
 		.sort();
 };
 
-const findInversePropertyNames = function(rootType, propName) {
+const findInversePropertyNames = function (rootType, propName) {
 	const { type, relationship, direction } = this.getType(rootType).properties[
 		propName
 	];
@@ -30,7 +30,7 @@ const findInversePropertyNames = function(rootType, propName) {
 	});
 };
 
-const findPropertyNames = function(rootType, propName) {
+const findPropertyNames = function (rootType, propName) {
 	const { type, relationship, direction } = this.getType(rootType).properties[
 		propName
 	];

--- a/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
+++ b/packages/tc-ui/src/pages/delete/__tests__/e2e-delete-record.cyp.js
@@ -30,9 +30,7 @@ describe('End-to-end - delete record', () => {
 		cy.get('[data-button-type="delete"]').click();
 
 		cy.window().then(win => {
-			cy.wrap(win)
-				.its('confirm')
-				.should('called', 1);
+			cy.wrap(win).its('confirm').should('called', 1);
 			cy.wrap(win)
 				.its('confirm.args.0')
 				.should('deep.eq', [deleteConfirmText]);

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-create-type.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-create-type.cyp.js
@@ -48,12 +48,8 @@ describe('End-to-end - record creation', () => {
 			});
 			cy.get('#id-code').type(code);
 			save();
-			cy.window()
-				.its('prompt')
-				.should('called', 1);
-			cy.window()
-				.its('prompt.args.0')
-				.should('deep.eq', [promptText]);
+			cy.window().its('prompt').should('called', 1);
+			cy.window().its('prompt.args.0').should('deep.eq', [promptText]);
 		});
 		it('can not create record if child record is not selected', () => {
 			cy.visit(`/MVRType/create`, {
@@ -64,12 +60,8 @@ describe('End-to-end - record creation', () => {
 			cy.get('#id-code').type(code);
 			cy.get('#id-someString').type(someString);
 			save();
-			cy.window()
-				.its('prompt')
-				.should('called', 1);
-			cy.window()
-				.its('prompt.args.0')
-				.should('deep.eq', [promptText]);
+			cy.window().its('prompt').should('called', 1);
+			cy.window().its('prompt.args.0').should('deep.eq', [promptText]);
 		});
 		it('can create record with incomplete fields with "SAVE INCOMPLETE RECORD" option', () => {
 			cy.visit(`/MVRType/create`, {

--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
@@ -81,17 +81,13 @@ describe('End-to-end - edit record', () => {
 		cy.get('#code').should('have.text', code);
 
 		visitEditPage();
-		cy.get('[type="radio"]')
-			.first()
-			.check({ force: true });
+		cy.get('[type="radio"]').first().check({ force: true });
 		save();
 		cy.url().should('contain', `/MainType/${code}`);
 		cy.get('#someBoolean').should('have.text', 'Yes');
 
 		visitEditPage();
-		cy.get('[type="radio"]')
-			.eq(1)
-			.check({ force: true });
+		cy.get('[type="radio"]').eq(1).check({ force: true });
 		save();
 
 		cy.url().should('contain', `/MainType/${code}`);
@@ -137,9 +133,7 @@ describe('End-to-end - edit record', () => {
 			'have.text',
 			'Third',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 2);
+		cy.get('#someMultipleChoice').children().should('have.length', 2);
 
 		visitEditPage();
 		cy.get('#checkbox-someMultipleChoice-Third').uncheck({ force: true });
@@ -156,9 +150,7 @@ describe('End-to-end - edit record', () => {
 			'have.text',
 			'Second',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 2);
+		cy.get('#someMultipleChoice').children().should('have.length', 2);
 	});
 
 	it('can edit date type fields', () => {

--- a/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
+++ b/packages/tc-ui/src/primitives/multiple-choice/__tests__/e2e-record-multiple-choice.cyp.js
@@ -33,9 +33,7 @@ describe('End-to-end - record multiple choice value', () => {
 			'have.text',
 			'First',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 1);
+		cy.get('#someMultipleChoice').children().should('have.length', 1);
 	});
 
 	it('can record multiple choices', () => {
@@ -62,9 +60,7 @@ describe('End-to-end - record multiple choice value', () => {
 			'have.text',
 			'Third',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 2);
+		cy.get('#someMultipleChoice').children().should('have.length', 2);
 	});
 
 	it('can record all choices', () => {
@@ -100,9 +96,7 @@ describe('End-to-end - record multiple choice value', () => {
 			'have.text',
 			'Third',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 3);
+		cy.get('#someMultipleChoice').children().should('have.length', 3);
 	});
 
 	it('can deselect a choice', () => {
@@ -124,9 +118,7 @@ describe('End-to-end - record multiple choice value', () => {
 			'have.text',
 			'First',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 1);
+		cy.get('#someMultipleChoice').children().should('have.length', 1);
 
 		visitEditPage();
 		cy.get('#checkbox-someMultipleChoice-First').uncheck({ force: true });
@@ -167,9 +159,7 @@ describe('End-to-end - record multiple choice value', () => {
 			'have.text',
 			'Third',
 		);
-		cy.get('#someMultipleChoice')
-			.children()
-			.should('have.length', 3);
+		cy.get('#someMultipleChoice').children().should('have.length', 3);
 
 		visitEditPage();
 		cy.get('#checkbox-someMultipleChoice-First').uncheck({ force: true });

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-annotate-rich-relationships.cyp.js
@@ -84,9 +84,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.children()
-					.should('have.length', 7);
+				cy.wrap(parent).children().should('have.length', 7);
 				// someString,anotherString,someInteger,someEnum,
 				// someMultipleChoice,someBoolean,someFloat = 7
 			},
@@ -96,9 +94,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.children()
-					.should('have.length', 2);
+				cy.wrap(parent).children().should('have.length', 2);
 				// someString,anotherString
 			},
 		);
@@ -185,18 +181,10 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.find('#id-someString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someInteger')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someEnum')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someString').should('be.visible');
+				cy.wrap(parent).find('#id-anotherString').should('be.visible');
+				cy.wrap(parent).find('#id-someInteger').should('be.visible');
+				cy.wrap(parent).find('#id-someEnum').should('be.visible');
 				cy.wrap(parent)
 					.find('#checkbox-someMultipleChoice-First')
 					.should('be.visible');
@@ -212,9 +200,7 @@ describe('End-to-end - annotate rich relationship properties', () => {
 				cy.wrap(parent)
 					.find('#radio-someBoolean-No')
 					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someFloat')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someFloat').should('be.visible');
 			},
 		);
 
@@ -228,12 +214,8 @@ describe('End-to-end - annotate rich relationship properties', () => {
 
 		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.find('#id-someString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someString').should('be.visible');
+				cy.wrap(parent).find('#id-anotherString').should('be.visible');
 			},
 		);
 	});
@@ -267,21 +249,15 @@ describe('End-to-end - annotate rich relationship properties', () => {
 				cy.wrap(parent)
 					.find('#someInteger')
 					.should('have.text', '2023');
-				cy.wrap(parent)
-					.find('#someEnum')
-					.should('have.text', someEnum);
+				cy.wrap(parent).find('#someEnum').should('have.text', someEnum);
 				cy.wrap(parent)
 					.find('#someMultipleChoice span:first-of-type')
 					.should('have.text', 'First');
 				cy.wrap(parent)
 					.find('#someMultipleChoice span:last-of-type')
 					.should('have.text', 'Third');
-				cy.wrap(parent)
-					.find('#someBoolean')
-					.should('have.text', 'Yes');
-				cy.wrap(parent)
-					.find('#someFloat')
-					.should('have.text', '20.23');
+				cy.wrap(parent).find('#someBoolean').should('have.text', 'Yes');
+				cy.wrap(parent).find('#someFloat').should('have.text', '20.23');
 			});
 	});
 	it('can save annotations for one-to-many relationship', () => {

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-delete-relationships.cyp.js
@@ -156,9 +156,7 @@ describe('End-to-end - relationship deletion', () => {
 		save();
 
 		cy.url().should('contain', `/MainType/${code}`);
-		cy.get('#children')
-			.children()
-			.should('have.length', 2);
+		cy.get('#children').children().should('have.length', 2);
 		cy.get('#children>li').then(children => {
 			cy.wrap(children)
 				.eq(0)
@@ -190,9 +188,7 @@ describe('End-to-end - relationship deletion', () => {
 			.should('have.text', `${code}-first-child`)
 			.should('have.attr', 'href', `/ChildType/${code}-first-child`);
 
-		cy.get('#children')
-			.children()
-			.should('have.length', 1);
+		cy.get('#children').children().should('have.length', 1);
 
 		visitEditPage();
 		// remove remaining child

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-disply-rich-relationships.cyp.js
@@ -109,12 +109,8 @@ describe('End-to-end - display relationship properties', () => {
 				cy.wrap(list)
 					.find('#someString')
 					.should('have.text', 'lorem ipsum');
-				cy.wrap(list)
-					.find('#someEnum')
-					.should('have.text', 'First');
-				cy.wrap(list)
-					.find('#someBoolean')
-					.should('have.text', 'Yes');
+				cy.wrap(list).find('#someEnum').should('have.text', 'First');
+				cy.wrap(list).find('#someBoolean').should('have.text', 'Yes');
 			});
 	});
 
@@ -147,12 +143,8 @@ describe('End-to-end - display relationship properties', () => {
 			.should('have.text', `${code}-parent-two`)
 			.should('have.attr', 'href', `/ParentType/${code}-parent-two`);
 		cy.get(`${secondCuriousParentSelector}`).then(parent => {
-			cy.wrap(parent)
-				.find('#someString')
-				.should('not.exist');
-			cy.wrap(parent)
-				.find('#anotherString')
-				.should('not.exist');
+			cy.wrap(parent).find('#someString').should('not.exist');
+			cy.wrap(parent).find('#anotherString').should('not.exist');
 		});
 	});
 

--- a/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
+++ b/packages/tc-ui/src/primitives/relationship/__tests__/e2e-edit-rich-relationships.cyp.js
@@ -74,21 +74,11 @@ describe('End-to-end - edit relationship properties', () => {
 
 		cy.get('#ul-curiousChild .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.find('#id-someString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someInteger')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someEnum')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someString').should('be.visible');
+				cy.wrap(parent).find('#id-anotherString').should('be.visible');
+				cy.wrap(parent).find('#id-someString').should('be.visible');
+				cy.wrap(parent).find('#id-someInteger').should('be.visible');
+				cy.wrap(parent).find('#id-someEnum').should('be.visible');
 				cy.wrap(parent)
 					.find('#checkbox-someMultipleChoice-First')
 					.should('be.visible');
@@ -104,9 +94,7 @@ describe('End-to-end - edit relationship properties', () => {
 				cy.wrap(parent)
 					.find('#radio-someBoolean-No')
 					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-someFloat')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someFloat').should('be.visible');
 			},
 		);
 
@@ -120,12 +108,8 @@ describe('End-to-end - edit relationship properties', () => {
 
 		cy.get('#ul-curiousParent .treecreeper-relationship-annotate').then(
 			parent => {
-				cy.wrap(parent)
-					.find('#id-someString')
-					.should('be.visible');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.should('be.visible');
+				cy.wrap(parent).find('#id-someString').should('be.visible');
+				cy.wrap(parent).find('#id-anotherString').should('be.visible');
 			},
 		);
 	});
@@ -176,19 +160,10 @@ describe('End-to-end - edit relationship properties', () => {
 					.find('#id-someFloat')
 					.should('have.value', '12.53');
 
-				cy.wrap(parent)
-					.find('#id-someString')
-					.type(' edited');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.type(' edited');
-				cy.wrap(parent)
-					.find('#id-someInteger')
-					.clear()
-					.type(2023);
-				cy.wrap(parent)
-					.find('#id-someEnum')
-					.select('Third');
+				cy.wrap(parent).find('#id-someString').type(' edited');
+				cy.wrap(parent).find('#id-anotherString').type(' edited');
+				cy.wrap(parent).find('#id-someInteger').clear().type(2023);
+				cy.wrap(parent).find('#id-someEnum').select('Third');
 
 				cy.wrap(parent)
 					.find('#checkbox-someMultipleChoice-First')
@@ -205,10 +180,7 @@ describe('End-to-end - edit relationship properties', () => {
 				cy.wrap(parent)
 					.find('#radio-someBoolean-No')
 					.check({ force: true });
-				cy.wrap(parent)
-					.find('#id-someFloat')
-					.clear()
-					.type(20.23);
+				cy.wrap(parent).find('#id-someFloat').clear().type(20.23);
 			},
 		);
 		save();
@@ -230,18 +202,12 @@ describe('End-to-end - edit relationship properties', () => {
 				cy.wrap(parent)
 					.find('#someInteger')
 					.should('have.text', '2023');
-				cy.wrap(parent)
-					.find('#someEnum')
-					.should('have.text', 'Third');
+				cy.wrap(parent).find('#someEnum').should('have.text', 'Third');
 				cy.wrap(parent)
 					.find('#someMultipleChoice span:first-of-type')
 					.should('have.text', 'Second');
-				cy.wrap(parent)
-					.find('#someBoolean')
-					.should('have.text', 'No');
-				cy.wrap(parent)
-					.find('#someFloat')
-					.should('have.text', '20.23');
+				cy.wrap(parent).find('#someBoolean').should('have.text', 'No');
+				cy.wrap(parent).find('#someFloat').should('have.text', '20.23');
 			});
 	});
 
@@ -396,20 +362,14 @@ describe('End-to-end - edit relationship properties', () => {
 					.should('have.value', '12.53');
 
 				// edit
-				cy.wrap(parent)
-					.find('#id-someString')
-					.type(' edited');
-				cy.wrap(parent)
-					.find('#id-anotherString')
-					.type(' edited');
+				cy.wrap(parent).find('#id-someString').type(' edited');
+				cy.wrap(parent).find('#id-anotherString').type(' edited');
 				cy.wrap(parent)
 					.find('#id-someInteger')
 					.clear()
 					// this will make the form submission error as the value is not a finite integer
 					.type(20.23);
-				cy.wrap(parent)
-					.find('#id-someEnum')
-					.select('Third');
+				cy.wrap(parent).find('#id-someEnum').select('Third');
 				cy.wrap(parent)
 					.find('#checkbox-someMultipleChoice-First')
 					.uncheck({ force: true });

--- a/packages/tc-ui/src/primitives/relationship/lib/debounce.js
+++ b/packages/tc-ui/src/primitives/relationship/lib/debounce.js
@@ -1,7 +1,7 @@
 module.exports = function debounce(callback, delay = 100) {
 	let timeoutID;
 
-	return function(...args) {
+	return function (...args) {
 		clearTimeout(timeoutID);
 		timeoutID = setTimeout(() => callback(...args), delay);
 	};

--- a/packages/tc-ui/src/test-helpers/cypress.js
+++ b/packages/tc-ui/src/test-helpers/cypress.js
@@ -106,9 +106,7 @@ const populateMainTypeFields = () => {
 	cy.get('input[name=someString]').type(someString);
 	cy.get('textarea[name=someDocument]').type(someDocument);
 	cy.get('textarea[name=anotherDocument]').type(anotherDocument);
-	cy.get('[type="radio"]')
-		.first()
-		.check({ force: true });
+	cy.get('[type="radio"]').first().check({ force: true });
 	cy.get('select[name=someEnum]').select(someEnum);
 	cy.get('#checkbox-someMultipleChoice-First').check({ force: true });
 	cy.get('#checkbox-someMultipleChoice-Third').check({ force: true });
@@ -406,18 +404,10 @@ const createMainTypeRecordWithChildren = async (
 
 const populateCuriousChildRelationshipFields = () => {
 	cy.get('#ul-curiousChild').then(curiousChild => {
-		cy.wrap(curiousChild)
-			.find('#id-someString')
-			.type(someString);
-		cy.wrap(curiousChild)
-			.find('#id-anotherString')
-			.type(anotherString);
-		cy.wrap(curiousChild)
-			.find('#id-someInteger')
-			.type(2023);
-		cy.wrap(curiousChild)
-			.find('#id-someEnum')
-			.select(someEnum);
+		cy.wrap(curiousChild).find('#id-someString').type(someString);
+		cy.wrap(curiousChild).find('#id-anotherString').type(anotherString);
+		cy.wrap(curiousChild).find('#id-someInteger').type(2023);
+		cy.wrap(curiousChild).find('#id-someEnum').select(someEnum);
 		cy.wrap(curiousChild)
 			.find('#checkbox-someMultipleChoice-First')
 			.check({ force: true });
@@ -427,28 +417,18 @@ const populateCuriousChildRelationshipFields = () => {
 		cy.wrap(curiousChild)
 			.find('#radio-someBoolean-Yes')
 			.check({ force: true });
-		cy.wrap(curiousChild)
-			.find('#id-someFloat')
-			.type(20.23);
+		cy.wrap(curiousChild).find('#id-someFloat').type(20.23);
 	});
 };
 
 const populateCuriousParent1RelationshipFields = parent => {
-	cy.wrap(parent)
-		.find('#id-someString')
-		.type(someString);
-	cy.wrap(parent)
-		.find('#id-anotherString')
-		.type(anotherString);
+	cy.wrap(parent).find('#id-someString').type(someString);
+	cy.wrap(parent).find('#id-anotherString').type(anotherString);
 };
 
 const populateCuriousParent2RelationshipFields = parent => {
-	cy.wrap(parent)
-		.find('#id-someString')
-		.type('Parent two someString');
-	cy.wrap(parent)
-		.find('#id-anotherString')
-		.type('Parent two anotherString');
+	cy.wrap(parent).find('#id-someString').type('Parent two someString');
+	cy.wrap(parent).find('#id-anotherString').type('Parent two anotherString');
 };
 
 const setLockedRecord = codeLabel => {

--- a/packages/tc-ui/src/test-helpers/mainTypeData.json
+++ b/packages/tc-ui/src/test-helpers/mainTypeData.json
@@ -1,14 +1,14 @@
 {
-	"code": "e2e-demo",
-	"someDocument": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.",
-	"anotherDocument": "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
-	"someString": "Lorem ipsum dolor sit amet",
-	"someEnum": "Second",
-	"someInteger": 2020,
-	"anotherString": "There are many variations",
-	"someDate": "2020-01-15",
-	"someDatetime": "2020-01-15T13:00",
-	"someUrl": "https://google.com",
-	"promptText": "Please fill out all fields required for the minimum viable record before creating a new record.\nType SAVE INCOMPLETE RECORD below to proceed, or click cancel to return to the form",
-	"deleteConfirmText": "Are you sure you wish to delete?\n\nUnless you created something by accident, a more appropriate action is usually to mark the record as inactive, either in the Is Active or Lifecycle Stage fields,"
+  "code": "e2e-demo",
+  "someDocument": "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.",
+  "anotherDocument": "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+  "someString": "Lorem ipsum dolor sit amet",
+  "someEnum": "Second",
+  "someInteger": 2020,
+  "anotherString": "There are many variations",
+  "someDate": "2020-01-15",
+  "someDatetime": "2020-01-15T13:00",
+  "someUrl": "https://google.com",
+  "promptText": "Please fill out all fields required for the minimum viable record before creating a new record.\nType SAVE INCOMPLETE RECORD below to proceed, or click cancel to return to the form",
+  "deleteConfirmText": "Are you sure you wish to delete?\n\nUnless you created something by accident, a more appropriate action is usually to mark the record as inactive, either in the Is Active or Lifecycle Stage fields,"
 }


### PR DESCRIPTION
## Why?

rel-engage has a new major release v8.0. Most of our repos are not using this latest version. The new version includes some previously excluded files to follow similar linting rules.
For more details on changes, see the [v8.0 release notes](https://github.com/Financial-Times/rel-engage/releases/tag/v8.0.0).

## What?

- Updated rel-engage to v8.0 **and** its latest patch version.
- Applied all the new linting changes for code consistency.

### Anything in particular you'd like to highlight to reviewers?

This PR is created automatically using a script. Please double check the changes, since it might have made some unwanted changes.
For any questions regarding this PR, contact us on [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) or email us @ reliability.engineering@ft.com.  

We have used the `[skip ci]` tag in the commit message to prevent an overload of concurrent CircleCI builds. If you would like to run your CI pipeline on this PR, you can make an empty commit on this branch to trigger CI before merging the PR.

`git commit --allow-empty -m "Trigger CI"`