### PR TITLE
allow cypher properties in schema to be multiline

### DIFF
--- a/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/graphql-defs.spec.js
@@ -249,4 +249,32 @@ describe('graphql def creation', () => {
 			expect(generated).toMatch(new RegExp(`prop: String`));
 		});
 	});
+	describe('@cypher', () => {
+		it(`Outputs valid graphQL when @cypher directive invoked`, () => {
+			const schema = {
+				types: [
+					{
+						name: 'Fake',
+						description: 'Fake type description',
+						properties: {
+							prop: {
+								type: 'Fake',
+								description: 'a description',
+								cypher: `Multi
+line with
+"quotes"`,
+							},
+						},
+					},
+				],
+				enums: {},
+				stringPatterns,
+				primitiveTypes: {},
+			};
+			const generated = [].concat(...graphqlFromRawData(schema)).join('');
+			expect(generated).toMatch(
+				'prop: Fake @cypher(statement: "Multi\\nline with\\n\\"quotes\\"")',
+			);
+		});
+	});
 });

--- a/packages/tc-schema-sdk/data-accessors/graphql-defs.js
+++ b/packages/tc-schema-sdk/data-accessors/graphql-defs.js
@@ -38,7 +38,10 @@ const maybePaginate = ({ hasMany, isRelationship }) =>
 
 const maybeDirective = def => {
 	if (def.cypher) {
-		return `@cypher(statement: "${def.cypher}")`;
+		return `@cypher(statement: "${def.cypher
+			.replace(/"/g, '\\"')
+			.split(/\n/)
+			.join('\\n')}")`;
 	}
 	if (def.relationship) {
 		return `@relation(name: "${def.relationship}", direction: "${


### PR DESCRIPTION
## Why?

To avoid this sort of thing https://github.com/Financial-Times/biz-ops-schema/pull/281/files#diff-4f26967fe0a45c699d6bd9b23c4f0660R239-R252

## What?
Escapes quotes and new lines in the cypher statement and adds a test