### PR TITLE
Standardise CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# See here for more details on this file https://help.github.com/en/articles/about-code-owners
-
-# This file will automatically add the reliability-engineering team as reviewers for open PRs.
-# Feel free to change it to another team if appropriate
 * @financial-times/reliability-engineering


### PR DESCRIPTION
## Why?

We want to distribute pull requests around the team more equitably using github's new pull-panda like tooling. To do this, we want a single team added as codeowner for everything.

## What?

Adds a standard codeowners file specifying reliability-engineering as the ownning team.