### PR TITLE
fix redisplay of temporal fields on edit page after bad form submission

### DIFF
--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -37,6 +37,8 @@ describe('End-to-end - record Temporal type', () => {
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someTime').should('have.text', '12:15:30 PM');
+		visitEditPage();
+		cy.get('input[name=someTime]').should('have.value', '12:15:30')
 	});
 
 	it('can record date', () => {
@@ -58,6 +60,8 @@ describe('End-to-end - record Temporal type', () => {
 		save();
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDate').should('have.text', '15 January 2020');
+		visitEditPage();
+		cy.get('input[name=someDate]').should('have.value', '2020-01-15')
 	});
 
 	it('can record date-time', () => {
@@ -88,5 +92,7 @@ describe('End-to-end - record Temporal type', () => {
 			'have.text',
 			'15 January 2020, 1:00:00 PM',
 		);
+		visitEditPage();
+		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T13:00:00.000')
 	});
 });

--- a/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
+++ b/packages/tc-ui/src/primitives/temporal/__tests__/e2e-record-temporal.cyp.js
@@ -38,7 +38,7 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('#code').should('have.text', code);
 		cy.get('#someTime').should('have.text', '12:15:30 PM');
 		visitEditPage();
-		cy.get('input[name=someTime]').should('have.value', '12:15:30')
+		cy.get('input[name=someTime]').should('have.value', '12:15:30');
 	});
 
 	it('can record date', () => {
@@ -61,7 +61,7 @@ describe('End-to-end - record Temporal type', () => {
 		cy.get('#code').should('have.text', code);
 		cy.get('#someDate').should('have.text', '15 January 2020');
 		visitEditPage();
-		cy.get('input[name=someDate]').should('have.value', '2020-01-15')
+		cy.get('input[name=someDate]').should('have.value', '2020-01-15');
 	});
 
 	it('can record date-time', () => {
@@ -93,6 +93,9 @@ describe('End-to-end - record Temporal type', () => {
 			'15 January 2020, 1:00:00 PM',
 		);
 		visitEditPage();
-		cy.get('input[name=someDatetime]').should('have.value', '2020-01-15T13:00:00.000')
+		cy.get('input[name=someDatetime]').should(
+			'have.value',
+			'2020-01-15T13:00:00.000',
+		);
 	});
 });

--- a/packages/tc-ui/src/primitives/temporal/server.jsx
+++ b/packages/tc-ui/src/primitives/temporal/server.jsx
@@ -22,7 +22,15 @@ const formatTemporal = (value, type) => {
 };
 
 const convertValueForHTMLInput = (wrappedValue, type) => {
-	if (!(wrappedValue && wrappedValue.formatted)) return null;
+	// this block is to handle the case where the form errors and we have
+	// to accept and rerender the value (an ISO string) that was due to be sent
+	// to the server
+	if (typeof wrappedValue === 'string') {
+		wrappedValue = {formatted: wrappedValue}
+	}
+ 	if (!(wrappedValue && wrappedValue.formatted)) {
+		return null
+	};
 	const value = wrappedValue.formatted;
 
 	// HACK - we have never properly thought about what to do with timezones

--- a/packages/tc-ui/src/primitives/temporal/server.jsx
+++ b/packages/tc-ui/src/primitives/temporal/server.jsx
@@ -25,12 +25,12 @@ const convertValueForHTMLInput = (wrappedValue, type) => {
 	// this block is to handle the case where the form errors and we have
 	// to accept and rerender the value (an ISO string) that was due to be sent
 	// to the server
-	if (typeof wrappedValue === 'string') {
-		wrappedValue = {formatted: wrappedValue}
+	if (typeof wrappedValue === 'string' && wrappedValue.length > 0) {
+		wrappedValue = { formatted: wrappedValue };
 	}
- 	if (!(wrappedValue && wrappedValue.formatted)) {
-		return null
-	};
+	if (!(wrappedValue && wrappedValue.formatted)) {
+		return null;
+	}
 	const value = wrappedValue.formatted;
 
 	// HACK - we have never properly thought about what to do with timezones


### PR DESCRIPTION
## Why?

oggy from membership found a bug when trying to update a record https://financialtimes.slack.com/archives/C0LJJ8UUX/p1604580902010800?thread_ts=1604313376.413800&cid=C0LJJ8UUX

After some investigation I found that if a record contains some already populated temporal fields, but something else causes an error in form submission, then when the form is rerendered those temporal values are lost

## What?
When rendering the form originally using GraphQL data the values are of the form `myDate: formatted: 'An ISO string'}`. But when submitting the form the data is converted to `myDate: 'An ISO string'` (which is what the REST api expects). After an error this data is passed back to the form to render and the component previously foudn there was no `formatted` property and therefore treated it as `null`.

I've added a check for a non-empty string now, which wraps the value in an object.

I did think about a refactor to give each component a `parseFromGraphQL` and a `parseFromFormData` helper, but seeing as other components which already have to handle similar stuff (notably, `Relationship` does) already do it by embedding some logic in the component, I figured I'd stick to that pattern for now. 