### PR TITLE
Allow undefined in resolve

### DIFF
--- a/packages/tc-api-graphql/lib/get-augmented-schema.js
+++ b/packages/tc-api-graphql/lib/get-augmented-schema.js
@@ -78,6 +78,7 @@ const getAugmentedSchema = ({
 			},
 		},
 		resolvers,
+		allowUndefinedInResolve: true,
 		config: {
 			query: excludeTypes ? { exclude: excludeTypes } : true,
 			mutation: false,


### PR DESCRIPTION
## Why?

When adding custom resolvers that traverse nested objects (e.g. in SOS) the absence of a property typically means just return `null`, but while this does resolve to `null` it also triggers the following ugly error:

```
 {
          "message": "Resolve function for \"SOSV1Facets.dataRecovery\" returned undefined",
          "locations": [
            {
              "line": 6,
              "column": 5
            }
          ],
          "path": [
            "System",
            "sosV1",
            "facets",
            "dataRecovery"
          ],
          "extensions": {
            "code": "INTERNAL_SERVER_ERROR"
          }
        }
```
## What?
Use the graphql option to suppress these errors. It's a global option which I feel a bit uncomfortable with, but if we find it useful to re-enable in future we can do so, and implement suppression rules in the places we do want them