### PR TITLE
fix MVP submit prevention

### DIFF
--- a/packages/tc-ui/src/pages/edit/browser.js
+++ b/packages/tc-ui/src/pages/edit/browser.js
@@ -59,12 +59,16 @@ const fieldValueCheckers = {
 	temporal: field => !!field.querySelector('input').value,
 	number: field => !!field.querySelector('input').value,
 	'large-text': field => !!field.querySelector('textarea').value,
-	enum: field => !!field.querySelector('select').value,
+	enum: field => {
+		const { value } = field.querySelector('select');
+		return !!value && value !== 'null';
+	},
 	boolean: field =>
 		!![...field.querySelectorAll('input')].some(input => input.checked),
 	relationship: field =>
 		!![...field.querySelectorAll('input[type="hidden"]')].every(
-			input => !!input.value && input.value !== '[]',
+			input =>
+				!!input.value && input.value !== '[]' && input.value !== 'null',
 		),
 };
 


### PR DESCRIPTION
## Why?
Fixes #195
Fixes https://github.com/Financial-Times/biz-ops-admin/issues/532

## What?
Treats string values of 'null' as empty. (Some previous change evidently meant null is now output instead of undefined/''.