### PR TITLE
implement force delete in the API

### DIFF
--- a/packages/tc-api-rest-handlers/README.md
+++ b/packages/tc-api-rest-handlers/README.md
@@ -94,6 +94,7 @@ The `metadata` object is typically constructed from information sent to the appl
 |                    |                   | `merge`            | Existing relationships will be kept, and ones defined in the body will also be created                                                                                  |
 |                    |                   | `replace`          | Existing relationships will be replaced by those specified in the body                                                                                                  |
 | richRelationship   | get               | `true`             | If the body has any relationships, it provides more information about the relationships than just their `code`                                                          |
+| force              | delete            | `true`             | Allows records to be deleted even if attached to other records                                                                                                          |
 
 ##### Field locking
 

--- a/packages/tc-api-rest-handlers/delete.js
+++ b/packages/tc-api-rest-handlers/delete.js
@@ -3,6 +3,7 @@ const { executeQuery } = require('./lib/neo4j-model');
 const { validateInput } = require('./lib/validation');
 const { getNeo4jRecord } = require('./lib/read-helpers');
 const { broadcast } = require('./lib/events');
+const { getAllRelationships } = require('./lib/relationships/input');
 
 const deleteHandler = ({
 	documentStore,
@@ -34,8 +35,17 @@ const deleteHandler = ({
 	}
 
 	try {
-		const neo4jResult = await executeQuery(query, { code });
-		broadcast({ action: 'DELETE', code, type, neo4jResult });
+		await executeQuery(query, { code });
+		broadcast({
+			action: 'DELETE',
+			code,
+			type,
+			// Gets all the relationship properties of the original neo4j record
+			removedRelationships: getAllRelationships(
+				type,
+				prefetchResult.toJson({ type, excludeMeta: true }),
+			),
+		});
 	} catch (error) {
 		logger.error(
 			{

--- a/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
+++ b/packages/tc-api-rest-handlers/lib/events/__tests__/events-integration.spec.js
@@ -73,6 +73,23 @@ describe('Rest events module integration', () => {
 			expect(emitSpy).toHaveBeenCalledTimes(1);
 			expectDeleteEvent(mainType, mainCode);
 		});
+		it('will send extra UPDATE events when connected to related nodes', async () => {
+			const [main, child] = await Promise.all([
+				createMainNode(),
+				createNode(childType, { code: childCode }),
+			]);
+			await connectNodes(main, 'HAS_CHILD', child);
+
+			const { status } = await deleteHandler()({
+				...input,
+				query: { force: true },
+			});
+
+			expect(status).toBe(204);
+			expect(emitSpy).toHaveBeenCalledTimes(2);
+			expectDeleteEvent(mainType, mainCode);
+			expectUpdateEvent(childType, childCode, ['isChildOf']);
+		});
 	});
 
 	describe('POST', () => {

--- a/packages/tc-api-rest-handlers/lib/events/index.js
+++ b/packages/tc-api-rest-handlers/lib/events/index.js
@@ -46,17 +46,15 @@ const makeEvents = ({
 	neo4jResult,
 	requestId,
 }) => {
-	if (action === 'DELETE') {
-		return [
-			{
-				action: 'DELETE',
-				type,
-				code,
-			},
-		];
-	}
-
 	const events = [];
+
+	if (action === 'DELETE') {
+		events.push({
+			action: 'DELETE',
+			type,
+			code,
+		});
+	}
 
 	if (updatedProperties.length) {
 		if (action === 'UPDATE') {

--- a/packages/tc-api-rest-handlers/lib/events/related-events.js
+++ b/packages/tc-api-rest-handlers/lib/events/related-events.js
@@ -77,7 +77,6 @@ const makeRemovedRelationshipEvents = (nodeType, removedRelationships = {}) =>
 		getEventType: () => 'UPDATE',
 		getUpdatedProperties: ({ rootType, propName }) =>
 			schema.findInversePropertyNames(rootType, propName),
-
 		relationships: removedRelationships,
 	});
 

--- a/packages/tc-api-rest-handlers/lib/relationships/input.js
+++ b/packages/tc-api-rest-handlers/lib/relationships/input.js
@@ -179,6 +179,15 @@ const getChangedRelationships = ({ type, initialContent, newContent }) => {
 	return newRelationships.reduce(entriesToObject, {});
 };
 
+const getAllRelationships = (type, payload = {}) => {
+	const isRelationship = identifyRelationships(type);
+	return Object.fromEntries(
+		Object.entries(payload).filter(([propName]) =>
+			isRelationship(propName),
+		),
+	);
+};
+
 const containsRelationshipData = (type, payload = {}) => {
 	const isRelationship = identifyRelationships(type);
 	return Object.entries(getType(type).properties)
@@ -217,6 +226,7 @@ const normaliseRelationshipProps = (type, body = {}) => {
 };
 
 module.exports = {
+	getAllRelationships,
 	getWriteRelationships,
 	getChangedRelationships,
 	getRemovedRelationships,


### PR DESCRIPTION
## Why?

Long standing need to be able to delete records with relationships for managing data in bulk importers, and for easy cleanup of records that no longer need to exist.

## What?

- Adds a `force=true` option to DELETE requests
- updates the events implementation to send update events for any related systems