### PR TITLE
Update schema validator - DRAFT

### DIFF
--- a/packages/tc-schema-validator/validation/json-schema/type.js
+++ b/packages/tc-schema-validator/validation/json-schema/type.js
@@ -73,6 +73,7 @@ const getPropertiesSchema = ({ forRelationships = false } = {}) => {
 			hasMany: { type: 'boolean' },
 			trueLabel: { type: 'string' },
 			falseLabel: { type: 'string' },
+			otherNodeName: {type: 'string', pattern: PROPERTY_NAME },
 		},
 		required: ['label', 'description', 'type'],
 		additionalProperties: false,
@@ -200,7 +201,7 @@ const fromOrTo = {
 	properties: {
 		type: { type: 'string', enum: types },
 		hasMany: { type: 'boolean' },
-		otherNodeName: {type: 'string'},
+		otherNodeName: {type: 'string', pattern: PROPERTY_NAME},
 	},
 };
 

--- a/packages/tc-schema-validator/validation/json-schema/type.js
+++ b/packages/tc-schema-validator/validation/json-schema/type.js
@@ -200,6 +200,7 @@ const fromOrTo = {
 	properties: {
 		type: { type: 'string', enum: types },
 		hasMany: { type: 'boolean' },
+		otherNodeName: {type: 'string'},
 	},
 };
 

--- a/packages/tc-schema-validator/validation/json-schema/type.js
+++ b/packages/tc-schema-validator/validation/json-schema/type.js
@@ -73,7 +73,7 @@ const getPropertiesSchema = ({ forRelationships = false } = {}) => {
 			hasMany: { type: 'boolean' },
 			trueLabel: { type: 'string' },
 			falseLabel: { type: 'string' },
-			otherNodeName: {type: 'string', pattern: PROPERTY_NAME },
+			otherNodeName: { type: 'string', pattern: PROPERTY_NAME },
 		},
 		required: ['label', 'description', 'type'],
 		additionalProperties: false,
@@ -201,7 +201,7 @@ const fromOrTo = {
 	properties: {
 		type: { type: 'string', enum: types },
 		hasMany: { type: 'boolean' },
-		otherNodeName: {type: 'string', pattern: PROPERTY_NAME },
+		otherNodeName: { type: 'string', pattern: PROPERTY_NAME },
 	},
 };
 


### PR DESCRIPTION
## Why?

Update the schema validator as a part of the Neo4j upgrade.

Make these tests pass, and add a few more as per this [Jira ticket](https://financialtimes.atlassian.net/browse/RE-2278)

```
$ TREECREEPER_SCHEMA_DIRECTORY=example-schema packages/tc-schema-validator/validation/index.js
Validating treecreeper schema files
ValidationError: validation failed
    at /treecreeper/packages/tc-schema-validator/validation/index.js:100:15
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  errors: [
    {
      params: { additionalProperty: 'otherNodeName' },
      message: 'should NOT have additional properties',
      signpost: 'Problem in the `from` section of the `CuriousSibling` relationship type'
    },
    {
      params: { additionalProperty: 'otherNodeName' },
      message: 'should NOT have additional properties',
      signpost: 'Problem in the `to` section of the `CuriousSibling` relationship type'
    },
    {
      params: { additionalProperty: 'otherNodeName' },
      message: 'should NOT have additional properties',
      signpost: 'Problem in the `youngerSiblings` property of the `MainType` type'
    },
    {
      params: { additionalProperty: 'otherNodeName' },
      message: 'should NOT have additional properties',
      signpost: 'Problem in the `olderSiblings` property of the `MainType` type'
    }
  ],
  validation: true,
  ajv: true
}
Treecreeper schema files invalid
```

## What?

- [x] Make the schema validation pass after adding the new property. 
   - [x] Updated the to/from relationship to allow `otherNodeName ` property. 
   - [x] Updated the type property to allow `otherNodeName` property.

- [ ] Removing the new property from where it is used in the MainType file should cause tests to fail with nice error message
- [ ] Removing the new property from where it is used in the CuriousSibling file should cause tests to fail with nice error message
- [ ] Adding the property on a relationship where it’s not needed (e.g. from MainType to ChildType) should  cause tests to fail with nice error message
- [ ] Adding the property in a relationship type where it’s not needed (e.g. in `CuriousChild`) should cause tests to fail with nice error message

### Anything in particular you'd like to highlight to reviewers?

This is WIP. I have created a PR to encourage collaboration and make code reviews easier.

## Screenshots / Images

