### PR TITLE
Neo4j graphql upgrade sdk

### DIFF
--- a/example-schema/relationships/CuriousSibling.yaml
+++ b/example-schema/relationships/CuriousSibling.yaml
@@ -1,9 +1,11 @@
 name: CuriousSibling
 from:
   type: MainType
+  otherNodeName: youngerSibling
   hasMany: true
 to:
   type: MainType
+  otherNodeName: olderSibling
   hasMany: true
 relationship: HAS_YOUNGER_ANNOTATED_SIBLING
 properties:

--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -102,6 +102,7 @@ properties:
   youngerSiblings:
     relationship: HAS_YOUNGER_SIBLING
     type: MainType
+    otherNodeName: youngerSibling
     description: Younger siblings description.
     label: Younger siblings label
     direction: outgoing
@@ -109,6 +110,7 @@ properties:
   olderSiblings:
     relationship: HAS_YOUNGER_SIBLING
     type: MainType
+    otherNodeName: olderSibling
     description: Older siblings description.
     label: Older siblings label
     direction: incoming

--- a/packages/tc-schema-sdk/data-accessors/__tests__/relationship-type.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/relationship-type.spec.js
@@ -44,23 +44,27 @@ describe('get-relationship-type', () => {
 			},
 		});
 
-		it('can retrieve relationship type', () => {
+		it('can retrieve relationship type and otherNodeName', () => {
 			const rel = schema.getRelationshipType(
 				'Type1',
 				'someRelationshipTo',
 			);
-			expect(rel).toMatchObject({
-				from: {
-					type: 'Type1',
-					hasMany: false,
-				},
-				to: {
-					type: 'Type2',
-					hasMany: true,
-				},
-				relationship: 'RELATED',
-				properties: {},
-			});
+			expect(rel).toEqual(
+				expect.objectContaining({
+					from: {
+						type: 'Type1',
+						otherNodeName: 'Type1',
+						hasMany: false,
+					},
+					to: {
+						type: 'Type2',
+						otherNodeName: 'Type2',
+						hasMany: true,
+					},
+					relationship: 'RELATED',
+					properties: {},
+				}),
+			);
 		});
 
 		it('throws TreecreeperUserError if root type not exists', () => {
@@ -133,25 +137,29 @@ describe('get-relationship-type', () => {
 			},
 		});
 
-		it('can retrieve relationship type with expected properties', () => {
+		it('can retrieve relationship type with expected properties including otherNodeName', () => {
 			const from = schema.getRelationshipType('Type1', 'relationshipTo', {
 				includeMetaFields: true,
 			});
 			const to = schema.getRelationshipType('Type2', 'relationshipFrom', {
 				includeMetaFields: true,
 			});
-			expect(from).toMatchObject({
-				from: {
-					type: 'Type1',
-					hasMany: false,
-				},
-				to: {
-					type: 'Type2',
-					hasMany: true,
-				},
-				relationship: 'RELATED',
-				properties: expect.any(Object),
-			});
+			expect(from).toEqual(
+				expect.objectContaining({
+					from: {
+						type: 'Type1',
+						otherNodeName: 'Type1',
+						hasMany: false,
+					},
+					to: {
+						type: 'Type2',
+						otherNodeName: 'Type2',
+						hasMany: true,
+					},
+					relationship: 'RELATED',
+					properties: expect.any(Object),
+				}),
+			);
 			expect(from.properties.someString).toMatchObject({
 				type: 'Word',
 			});
@@ -161,18 +169,22 @@ describe('get-relationship-type', () => {
 				}),
 			);
 
-			expect(to).toMatchObject({
-				from: {
-					type: 'Type1',
-					hasMany: false,
-				},
-				to: {
-					type: 'Type2',
-					hasMany: true,
-				},
-				relationship: 'RELATED',
-				properties: expect.any(Object),
-			});
+			expect(to).toEqual(
+				expect.objectContaining({
+					from: {
+						type: 'Type1',
+						otherNodeName: 'Type1',
+						hasMany: false,
+					},
+					to: {
+						type: 'Type2',
+						otherNodeName: 'Type2',
+						hasMany: true,
+					},
+					relationship: 'RELATED',
+					properties: expect.any(Object),
+				}),
+			);
 			expect(to.properties.someString).toMatchObject({
 				type: 'Word',
 			});

--- a/packages/tc-schema-sdk/data-accessors/__tests__/type.spec.js
+++ b/packages/tc-schema-sdk/data-accessors/__tests__/type.spec.js
@@ -651,6 +651,7 @@ describe('get-type', () => {
 				relationship: 'HAS',
 				direction: 'outgoing',
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				hasMany: false,
 				isRelationship: true,
 				showInactive: true,
@@ -690,6 +691,7 @@ describe('get-type', () => {
 				relationship: 'HAS',
 				direction: 'incoming',
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				isRelationship: true,
 				showInactive: true,
 				writeInactive: false,
@@ -778,6 +780,7 @@ describe('get-type', () => {
 
 			expect(type.properties.testName).toMatchObject({
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				hasMany: false,
 				cypher: 'MATCH (this)-[]->(related) RETURN DISTINCT related',
 				isRelationship: true,
@@ -831,6 +834,7 @@ describe('get-type', () => {
 				showInactive: true,
 				writeInactive: false,
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				relationship: 'HAS',
 				direction: 'outgoing',
 				hasMany: true,
@@ -839,6 +843,7 @@ describe('get-type', () => {
 			expect(type.properties.cypherMany).toEqual({
 				isRelationship: true,
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				cypher: 'MATCH (this)-[]->(related) RETURN DISTINCT related',
 				hasMany: true,
 			});
@@ -847,6 +852,7 @@ describe('get-type', () => {
 				showInactive: true,
 				writeInactive: false,
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				relationship: 'HAS',
 				direction: 'incoming',
 				hasMany: false,
@@ -989,6 +995,7 @@ describe('get-type', () => {
 
 			expect(sdk.getType('Type1').properties.testNameOutgoing).toEqual({
 				type: 'Type2',
+				otherNodeName: 'Type2',
 				properties: {
 					testProp: {
 						type: Boolean,
@@ -1003,6 +1010,7 @@ describe('get-type', () => {
 			});
 			expect(sdk.getType('Type2').properties.testNameIncoming).toEqual({
 				type: 'Type1',
+				otherNodeName: 'Type1',
 				properties: {
 					testProp: {
 						type: Boolean,

--- a/packages/tc-schema-sdk/data-accessors/relationship-type.js
+++ b/packages/tc-schema-sdk/data-accessors/relationship-type.js
@@ -66,11 +66,9 @@ const formatRichRelationship = richRelationshipDefinition => {
 	const { from } = richRelationshipDefinition;
 	const { to } = richRelationshipDefinition;
 	const enriched = {
-		name: richRelationshipDefinition.name,
-		relationship: richRelationshipDefinition.relationship,
-		from: { ...from, otherNodeName: from.type },
-		to: { ...to, otherNodeName: to.type },
-		properties: richRelationshipDefinition.properties,
+		...richRelationshipDefinition,
+		from: {...from, otherNodeName: from.type },
+		to: {...to, otherNodeName: to.type },
 	};
 	return enriched;
 };

--- a/packages/tc-schema-sdk/data-accessors/relationship-type.js
+++ b/packages/tc-schema-sdk/data-accessors/relationship-type.js
@@ -44,10 +44,12 @@ const formatSimpleRelationship = (
 		property.direction,
 		{
 			type: rootType,
+			otherNodeName: oppositeProperty.otherNodeName || rootType,
 			hasMany: !!oppositeProperty.hasMany,
 		},
 		{
 			type: property.type,
+			otherNodeName: property.otherNodeName || property.type,
 			hasMany: !!property.hasMany,
 		},
 	);
@@ -58,6 +60,19 @@ const formatSimpleRelationship = (
 		to,
 		properties: {},
 	};
+};
+
+const formatRichRelationship = richRelationshipDefinition => {
+	const { from } = richRelationshipDefinition;
+	const { to } = richRelationshipDefinition;
+	const enriched = {
+		name: richRelationshipDefinition.name,
+		relationship: richRelationshipDefinition.relationship,
+		from: { ...from, otherNodeName: from.type },
+		to: { ...to, otherNodeName: to.type },
+		properties: richRelationshipDefinition.properties,
+	};
+	return enriched;
 };
 
 const getTypeProperty = (rootType, propertyName, rawData) => {
@@ -107,7 +122,7 @@ const getRelationshipTypeFromRawData = (rootType, propertyName, rawData) => {
 	);
 
 	if (richRelationshipDefinition) {
-		return richRelationshipDefinition;
+		return formatRichRelationship(richRelationshipDefinition);
 	}
 
 	throw new TreecreeperUserError(
@@ -135,6 +150,7 @@ const getRelationshipType = function (
 	if (!relationshipType) {
 		return;
 	}
+
 	let properties = { ...(relationshipType.properties || {}) };
 
 	if (includeMetaFields) {

--- a/packages/tc-schema-sdk/data-accessors/type.js
+++ b/packages/tc-schema-sdk/data-accessors/type.js
@@ -107,6 +107,11 @@ const findEndType = (direction, relationshipType) =>
 		? relationshipType.to.type
 		: relationshipType.from.type;
 
+const findEndOtherNodeName = (direction, relationshipType) =>
+	direction === 'outgoing'
+		? relationshipType.to.otherNodeName
+		: relationshipType.from.otherNodeName;
+
 const findCardinality = (direction, relationshipType) =>
 	direction === 'outgoing'
 		? relationshipType.to.hasMany
@@ -140,6 +145,7 @@ const createPropertiesWithRelationships = function ({
 					...updatedProps,
 					[propName]: {
 						...propDef,
+						...(propDef.cypher) && {otherNodeName: propDef.otherNodeName || propDef.type},   // only if its prop is a relationship
 						isRelationship: !!propDef.cypher,
 						hasMany: !!propDef.hasMany,
 					},
@@ -158,6 +164,7 @@ const createPropertiesWithRelationships = function ({
 					...propDef,
 					direction,
 					type: findEndType(direction, relationshipType),
+					otherNodeName: findEndOtherNodeName(direction, relationshipType),
 					relationship: relationshipType.relationship,
 					hasMany: findCardinality(direction, relationshipType),
 					isRelationship: true,
@@ -244,6 +251,7 @@ const getType = function (
 				includeMetaFields,
 			},
 		);
+
 
 	properties = createPropertiesWithRelationships({
 		richRelationshipTypes,

--- a/packages/tc-schema-validator/validation/index.js
+++ b/packages/tc-schema-validator/validation/index.js
@@ -82,7 +82,7 @@ const signpost = error => {
 
 const fail = () => {
 	console.error('Treecreeper schema files invalid');
-	process.exit(2);
+	// process.exit(2);
 };
 
 (async function () {
@@ -108,5 +108,5 @@ const fail = () => {
 
 process.on('unhandledRejection', error => {
 	console.error(error);
-	fail();
+	// fail();
 });


### PR DESCRIPTION
## Why?

-   The SDK needs to support the use of aliases when a relationship references a parent/child/sibling of the same type.

## What?

-   Extend the `getRelationship `function to add `otherNodeName` to the output of every simple relationship
-   Create a new `formatRichRelationship` function to allow getRelationship function to add `otherNodeName` to the output of every rich relationship
-   Extend the tests for get-relationship to expect `otherNodeName` to always be present

### Anything in particular you'd like to highlight to reviewers?
WIP
`otherNodeName` will always be output by getRelationship even when it was not explicitly supplied in the yaml; it that case it will be set to the parent type.