### PR TITLE
Allow markdown in the descriptions and moreInformation for schema types.

### DIFF
--- a/example-schema/types/MainType.yaml
+++ b/example-schema/types/MainType.yaml
@@ -1,7 +1,15 @@
 name: MainType
-description: Description of MainType.
+description: |
+  Description of MainType.
+  - bullet 1
+  - bullet 2
+  - bullet 3
+  Some more text
 moreInformation: |
   More information for MainType
+  - bullet
+  *bold text*
+  - another bullet
 properties:
   code:
     type: Code

--- a/packages/tc-ui/src/lib/components/structure.jsx
+++ b/packages/tc-ui/src/lib/components/structure.jsx
@@ -1,5 +1,7 @@
 const React = require('react');
 
+const { markdownToHtml } = require('../../lib/markdown-to-html');
+
 const toKebabCase = string =>
 	string
 		.split(' ')
@@ -11,9 +13,13 @@ const Concept = ({ name, description, moreInformation }) => (
 		<div className="o-forms-title">
 			<div className="o-forms-title__main">A {name} is:</div>
 			<div className="description-text o-forms-title__prompt">
-				{description}
+				<div
+					dangerouslySetInnerHTML={{ __html: markdownToHtml(description) }}
+				/>
 				<p />
-				{moreInformation}
+				<div
+					dangerouslySetInnerHTML={{ __html: markdownToHtml(moreInformation) }}
+				/>
 			</div>
 		</div>
 	</aside>


### PR DESCRIPTION
## Why?

-   descriptions which included bullet points or formatting where being displayed on a single line without formatting

## What?

-   Added `markdownToHtml()` conversion before output of `description` or `moreInformation` in header aside.

### Anything in particular you'd like to highlight to reviewers?
no

### Screenshot
![image](https://user-images.githubusercontent.com/11228420/108735961-0ac93700-7529-11eb-8881-ee3a18c9021b.png)
