### PR TITLE
clearer message for schema doesn't exist error

### DIFF
--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -22,6 +22,16 @@ This is a little odd (and should be improved in future)
 
 Be aware of the idiosyncrasy above if you ever come across errors complaining that no data is available.
 
+#### Lifecycle guide
+
+- `schema.init()` - configures the schema library, telling it where to fetch the schema from and which methodology to use to update it in memory (these vary depending on lambda vs express and test vs prod). 
+- `schema.ready()` - makes the initial fetch for data and starts the polling interval. Returns a promise that resolves when the first set of data has been stored in memory.
+- `schema.getType()` etc, attempts to read to read data synchronously from memory. Errors if schema.ready() has not resolved yet
+
+So initialising is always a synchronous step (`init`), followed by an asynchronous step (`ready`) you need to await once, and then after that all the other method calls should be synchronous.
+
+The one exception is a call to `schema.refresh()` - asynchronous which must be called at the beginning of each lambda event handled because the background long-polling pattern does not work in lambda. 
+
 ### `init(options)`
 
 The package exports an `init(options)` function, that takes the following options:

--- a/packages/tc-schema-sdk/README.md
+++ b/packages/tc-schema-sdk/README.md
@@ -24,13 +24,13 @@ Be aware of the idiosyncrasy above if you ever come across errors complaining th
 
 #### Lifecycle guide
 
-- `schema.init()` - configures the schema library, telling it where to fetch the schema from and which methodology to use to update it in memory (these vary depending on lambda vs express and test vs prod). 
-- `schema.ready()` - makes the initial fetch for data and starts the polling interval. Returns a promise that resolves when the first set of data has been stored in memory.
-- `schema.getType()` etc, attempts to read to read data synchronously from memory. Errors if schema.ready() has not resolved yet
+-   `schema.init()` - configures the schema library, telling it where to fetch the schema from and which methodology to use to update it in memory (these vary depending on lambda vs express and test vs prod).
+-   `schema.ready()` - makes the initial fetch for data and starts the polling interval. Returns a promise that resolves when the first set of data has been stored in memory.
+-   `schema.getType()` etc, attempts to read to read data synchronously from memory. Errors if schema.ready() has not resolved yet
 
 So initialising is always a synchronous step (`init`), followed by an asynchronous step (`ready`) you need to await once, and then after that all the other method calls should be synchronous.
 
-The one exception is a call to `schema.refresh()` - asynchronous which must be called at the beginning of each lambda event handled because the background long-polling pattern does not work in lambda. 
+The one exception is a call to `schema.refresh()` - asynchronous which must be called at the beginning of each lambda event handled because the background long-polling pattern does not work in lambda.
 
 ### `init(options)`
 

--- a/packages/tc-schema-sdk/lib/raw-data-wrapper.js
+++ b/packages/tc-schema-sdk/lib/raw-data-wrapper.js
@@ -8,11 +8,12 @@ class RawDataWrapper {
 	checkDataExists() {
 		if (!this.rawData.schema) {
 			throw new Error(`Schema data does not exist.
-Check that you have configured biz-ops-schema correctly (see the README)
+Check that you have configured tc-schema-sdk correctly (see https://github.com/Financial-Times/treecreeper/tree/master/packages/tc-schema-sdk)
 and that you are using the correct refresh pattern for your environment
 and have waited for the first fetch of schema data to happen.
-
-If npm linking the schema locally, set \`updateMode: 'dev'\`
+Often this error occurs because a method of tc-schema-sdk is called once at the
+top level of a module; try calling it from within the function that uses the data
+instead.
 `);
 		}
 	}


### PR DESCRIPTION
## Why?

Difficult to debug when a method is being called before the schema is ready
## What?
- updates out of date docs in the message
- explicitly calls out the 'using in the top level of a module' antipattern