### PR TITLE
delete properties rather than storing empty strings

### DIFF
--- a/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
@@ -199,7 +199,13 @@ describe('rest document store integration', () => {
 				});
 				await neo4jTest('DocumentStoreTest', mainCode).exists();
 
-				expect(mockDocstorePost).not.toHaveBeenCalled();
+				expect(mockDocstorePost).toHaveBeenCalledWith(
+					'DocumentStoreTest',
+					mainCode,
+					{
+						firstDocumentProperty: null,
+					},
+				);
 			});
 
 			if (method === 'POST') {

--- a/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/document-store.spec.js
@@ -321,7 +321,9 @@ describe('rest document store integration', () => {
 			);
 		});
 
-		it('unsets a Document property when empty string provided', async () => {
+		// This, combined with a test in tc-api-s3-docstore, gives some confidence that
+		// deleting document properties is possible
+		it('Forwards empty document properties to the docstore to be handled appropriately', async () => {
 			await createMainNode();
 			const anotherDocFromS3 = {
 				secondDocumentProperty: 'another document from s3',
@@ -330,22 +332,17 @@ describe('rest document store integration', () => {
 				versionMarker,
 				body: anotherDocFromS3,
 			});
-			const { status, body } = await patchHandler({ documentStore })(
+			await patchHandler({ documentStore })(
 				getInput({
 					firstDocumentProperty: '',
 					secondDocumentProperty: 'another document',
 				}),
 			);
-
-			expect(status).toBe(200);
-			expect(body).toMatchObject({ code: mainCode, ...anotherDocFromS3 });
-
-			await neo4jTest('DocumentStoreTest', mainCode).exists();
-
 			expect(mockDocstorePatch).toHaveBeenCalledWith(
 				'DocumentStoreTest',
 				mainCode,
 				{
+					firstDocumentProperty: null,
 					secondDocumentProperty: 'another document',
 				},
 			);

--- a/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
+++ b/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
@@ -1,4 +1,3 @@
-const _isEmpty = require('lodash.isempty');
 const { getType } = require('@financial-times/tc-schema-sdk');
 
 const separateDocsFromBody = (nodeType, body = {}) => {
@@ -8,14 +7,9 @@ const separateDocsFromBody = (nodeType, body = {}) => {
 
 	Object.entries(body).forEach(([key, value]) => {
 		if (key.charAt(0) !== '!' && properties[key].type === 'Document') {
-			// We should check the value is empty only when type is Document
-			// because other type will be passed as boolean, number, etc...
-			// then _isEmpty() will returns true
-			if (!_isEmpty(value)) {
-				bodyDocuments[key] = body[key];
-			}
+			bodyDocuments[key] = value;
 		} else {
-			bodyNoDocs[key] = body[key];
+			bodyNoDocs[key] = value;
 		}
 	});
 

--- a/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
+++ b/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
@@ -6,7 +6,7 @@ const separateDocsFromBody = (nodeType, body = {}) => {
 	const bodyNoDocs = {};
 
 	Object.entries(body).forEach(([key, value]) => {
-		// checking for `!` avoids errors being thrown when iterating over 
+		// checking for `!` avoids errors being thrown when iterating over
 		// 'delete relationships' properties
 		if (key.charAt(0) !== '!' && properties[key].type === 'Document') {
 			bodyDocuments[key] = value;

--- a/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
+++ b/packages/tc-api-rest-handlers/lib/separate-documents-from-body.js
@@ -6,6 +6,8 @@ const separateDocsFromBody = (nodeType, body = {}) => {
 	const bodyNoDocs = {};
 
 	Object.entries(body).forEach(([key, value]) => {
+		// checking for `!` avoids errors being thrown when iterating over 
+		// 'delete relationships' properties
 		if (key.charAt(0) !== '!' && properties[key].type === 'Document') {
 			bodyDocuments[key] = value;
 		} else {

--- a/packages/tc-api-s3-document-store/__tests__/s3-docstore-patch.spec.js
+++ b/packages/tc-api-s3-document-store/__tests__/s3-docstore-patch.spec.js
@@ -147,4 +147,61 @@ describe('S3 document helper patch', () => {
 			VersionId: givenVersionMarker,
 		});
 	});
+
+	test('deletes when empty strings sent', async () => {
+		const givenSystemCode = 'docstore-patch-test';
+		const givenVersionMarker = 'Mw4owdmcWOlJIW.YZQRRsdksCXwPcTar';
+
+		const {
+			stubUpload,
+			stubGetObject,
+			stubDeleteOnUndo,
+			s3Instance,
+		} = mockS3Patch(givenVersionMarker);
+		const store = docstore(s3Instance);
+		const expectedData = createExampleBodyData();
+
+		const patchBody = {
+			someDocument: '',
+		};
+		const result = await store.patch(
+			consistentNodeType,
+			givenSystemCode,
+			patchBody,
+		);
+
+		const expectedBody = { anotherDocument: 'Another document' };
+		const callParams = {
+			Bucket: TREECREEPER_DOCSTORE_S3_BUCKET,
+			Key: `${consistentNodeType}/${givenSystemCode}`,
+			Body: JSON.stringify(expectedBody),
+			ContentType: 'application/json',
+		};
+
+		expect(result).toMatchObject({
+			versionMarker: givenVersionMarker,
+			body: expectedBody,
+			undo: expect.any(Function),
+		});
+		expect(stubUpload).toHaveBeenCalled();
+		expect(stubUpload).toHaveBeenCalledWith({
+			s3Instance,
+			params: callParams,
+			requestType: 'PATCH',
+		});
+		expect(stubGetObject).toHaveBeenCalled();
+		expect(stubGetObject).toHaveBeenCalledWith(
+			matcher(s3Instance, givenSystemCode),
+		);
+
+		const undoResult = await result.undo();
+		expect(undoResult).toMatchObject({
+			versionMarker: givenVersionMarker,
+		});
+		expect(stubDeleteOnUndo).toHaveBeenCalledWith({
+			Bucket: TREECREEPER_DOCSTORE_S3_BUCKET,
+			Key: `${consistentNodeType}/${givenSystemCode}`,
+			VersionId: givenVersionMarker,
+		});
+	});
 });

--- a/packages/tc-api-s3-document-store/__tests__/s3-docstore-patch.spec.js
+++ b/packages/tc-api-s3-document-store/__tests__/s3-docstore-patch.spec.js
@@ -258,4 +258,39 @@ describe('S3 document helper patch', () => {
 			VersionId: givenVersionMarker,
 		});
 	});
+	test('does not write when only nulls and empty strings sent', async () => {
+		const givenSystemCode = 'docstore-patch-test';
+		const givenVersionMarker = 'Mw4owdmcWOlJIW.YZQRRsdksCXwPcTar';
+
+		const { stubUpload, stubGetObject, s3Instance } = mockS3Patch(
+			givenVersionMarker,
+		);
+		const store = docstore(s3Instance);
+
+		stubGetObject.mockResolvedValue({
+			body: {},
+		});
+		const patchBody = {
+			someDocument: null,
+			anotherDocument: '',
+		};
+		const result = await store.patch(
+			consistentNodeType,
+			givenSystemCode,
+			patchBody,
+		);
+
+		const expectedBody = {};
+		expect(result).toMatchObject({
+			body: expectedBody,
+		});
+		expect(result).not.toMatchObject({
+			undo: expect.any(Function),
+		});
+		expect(stubUpload).not.toHaveBeenCalled();
+		expect(stubGetObject).toHaveBeenCalled();
+		expect(stubGetObject).toHaveBeenCalledWith(
+			matcher(s3Instance, givenSystemCode),
+		);
+	});
 });

--- a/packages/tc-api-s3-document-store/patch.js
+++ b/packages/tc-api-s3-document-store/patch.js
@@ -11,7 +11,10 @@ const s3Patch = async ({ s3Instance, bucketName, type, code, body }) => {
 		code,
 	});
 	const changedProperties = Object.keys(body).filter(
-		key => body[key] !== existingBody[key],
+		// check that at least one has a value to avoid e.g. null !== undefined causing
+		// an unnecessary write (the api will send nulls sometimes, but the json object will
+		// contain undefineds)
+		key => (body[key] || existingBody[key]) && body[key] !== existingBody[key],
 	);
 
 	// If PATCHing body is completely same with existing body,
@@ -30,7 +33,9 @@ const s3Patch = async ({ s3Instance, bucketName, type, code, body }) => {
 
 	const newBodyDocument = Object.assign(existingBody, body);
 
-	const newBodyWithoutEmpty = Object.fromEntries(Object.entries(newBodyDocument).filter(([, value]) => !!value))
+	const newBodyWithoutEmpty = Object.fromEntries(
+		Object.entries(newBodyDocument).filter(([, value]) => !!value),
+	);
 
 	const params = {
 		Bucket: bucketName,

--- a/packages/tc-api-s3-document-store/patch.js
+++ b/packages/tc-api-s3-document-store/patch.js
@@ -14,7 +14,8 @@ const s3Patch = async ({ s3Instance, bucketName, type, code, body }) => {
 		// check that at least one has a value to avoid e.g. null !== undefined causing
 		// an unnecessary write (the api will send nulls sometimes, but the json object will
 		// contain undefineds)
-		key => (body[key] || existingBody[key]) && body[key] !== existingBody[key],
+		key =>
+			(body[key] || existingBody[key]) && body[key] !== existingBody[key],
 	);
 
 	// If PATCHing body is completely same with existing body,


### PR DESCRIPTION
## Why?

Biz Ops could not unset any strings stored in Document properties

Fixes https://github.com/Financial-Times/biz-ops-admin/issues/548
## What?

- There was some code explicitly preventing passing empty strings to the s3 document store. While this has good intentions - don't want to create documents when we have no data to write - it's premature and means that those empty properties don't get through to the docstore in situations where the user wants to delete something. This code has been removed and the test updated to expect that a null gets passed through
- Diffing logic in the docstore has been updated to avoid deciding a write is needed when comparing `null` (from the API) with `undefined` (from S3), 
- Before writing to S3 the docstore deletes any falsy values from the body, which effectively deletes them from s3

TODO

- [x] test to make sure does not write when posting an object just containing an empty string