### PR TITLE
avoid removing test properties from schema in test apps

### DIFF
--- a/packages/tc-schema-sdk/__tests__/test-schema-properties.spec.js
+++ b/packages/tc-schema-sdk/__tests__/test-schema-properties.spec.js
@@ -95,7 +95,6 @@ const schemaFixture = {
 };
 
 describe('test schema properties', () => {
-
 	// Note that this behaviour is the opposite as tc-schema-publisher
 	// This is because, consider teh test environment:
 	// 1. tc-schema-publisher explicitly publishes including test properties
@@ -104,7 +103,6 @@ describe('test schema properties', () => {
 	it('includes test properties by default', async () => {
 		const schema = new SDK({
 			schemaData: { schema: schemaFixture },
-			includeTestDefinitions: true,
 		});
 		await schema.ready();
 		expect(schema.getTypes().length).toEqual(2);
@@ -129,7 +127,10 @@ describe('test schema properties', () => {
 	});
 
 	it('excludes test properties on demand', async () => {
-		const schema = new SDK({ schemaData: { schema: schemaFixture } });
+		const schema = new SDK({
+			schemaData: { schema: schemaFixture },
+			includeTestDefinitions: false,
+		});
 		await schema.ready();
 		expect(schema.getTypes().length).toEqual(1);
 		expect(schema.getTypes()[0].name).toEqual('TypeA');

--- a/packages/tc-schema-sdk/__tests__/test-schema-properties.spec.js
+++ b/packages/tc-schema-sdk/__tests__/test-schema-properties.spec.js
@@ -95,25 +95,13 @@ const schemaFixture = {
 };
 
 describe('test schema properties', () => {
-	it('excludes test properties by default', async () => {
-		const schema = new SDK({ schemaData: { schema: schemaFixture } });
-		await schema.ready();
-		expect(schema.getTypes().length).toEqual(1);
-		expect(schema.getTypes()[0].name).toEqual('TypeA');
-		expect(Object.keys(schema.getTypes()[0].properties)).toEqual([
-			'code',
-			'stringPropertyA',
-		]);
-		expect(Object.keys(schema.getEnums())).toEqual(['AnEnum']);
-		expect(Object.keys(schema.getTypes({ grouped: true }))).toEqual([
-			'prod',
-		]);
-		expect(schema.getTypes({ grouped: true }).prod.types[0].name).toEqual(
-			'TypeA',
-		);
-	});
 
-	it('includes test properties on demand', async () => {
+	// Note that this behaviour is the opposite as tc-schema-publisher
+	// This is because, consider teh test environment:
+	// 1. tc-schema-publisher explicitly publishes including test properties
+	// 2. Now that they are in, we don't want any instance of the SDK running in a
+	//		test app to strip them out again!
+	it('includes test properties by default', async () => {
 		const schema = new SDK({
 			schemaData: { schema: schemaFixture },
 			includeTestDefinitions: true,
@@ -137,6 +125,24 @@ describe('test schema properties', () => {
 		);
 		expect(schema.getTypes({ grouped: true }).test.types[0].name).toEqual(
 			'TypeB',
+		);
+	});
+
+	it('excludes test properties on demand', async () => {
+		const schema = new SDK({ schemaData: { schema: schemaFixture } });
+		await schema.ready();
+		expect(schema.getTypes().length).toEqual(1);
+		expect(schema.getTypes()[0].name).toEqual('TypeA');
+		expect(Object.keys(schema.getTypes()[0].properties)).toEqual([
+			'code',
+			'stringPropertyA',
+		]);
+		expect(Object.keys(schema.getEnums())).toEqual(['AnEnum']);
+		expect(Object.keys(schema.getTypes({ grouped: true }))).toEqual([
+			'prod',
+		]);
+		expect(schema.getTypes({ grouped: true }).prod.types[0].name).toEqual(
+			'TypeA',
 		);
 	});
 });

--- a/packages/tc-schema-sdk/sdk.js
+++ b/packages/tc-schema-sdk/sdk.js
@@ -13,7 +13,7 @@ const relationshipType = require('./data-accessors/relationship-type');
 const { SchemaUpdater } = require('./lib/updater');
 const utils = require('./lib/utils');
 
-const defaultOptions = { includeTestDefinitions: false };
+const defaultOptions = { includeTestDefinitions: true };
 
 class SDK {
 	constructor(userOptions = {}) {


### PR DESCRIPTION
## Why?
Testing out in Biz Ops Admin locally I found that despite the test properties being defined in the test schema, these were being stripped out by the app when using the latest schema SDK - not what we ant at all!

![image](https://user-images.githubusercontent.com/447559/113895900-55dd9780-97c1-11eb-9895-0b1f490ca735.png)

## What?
Tweaked the config so that
- including test properties defaults to _true_ in the SDK (used by apps) so in test apps no test schema properties get stripped out
- including test properties remains unchanged, still defaulting to _false_, so that we don't accidentally publish test schema bits and pieces to prod