### PR TITLE
fix: regex matcher for SystemCodes

### DIFF
--- a/packages/tc-schema-validator/validation/json-schema/references.js
+++ b/packages/tc-schema-validator/validation/json-schema/references.js
@@ -24,7 +24,7 @@ module.exports = {
 	simpleTypes: [...validEnums, ...primitiveTypeNames],
 	complexTypes: [...typeNames, ...relationshipTypeNames],
 	stringPatterns: Object.keys(stringPatterns),
-	SYSTEM_CODE: '^[a-z][\\-a-z]+[a-z]$',
+	SYSTEM_CODE: '^[a-z][a-z0-9-]+[a-z0-9]$',
 	TYPE_NAME: '^[A-Z][a-zA-Z]+$',
 	CAPITAL_SNAKE_CASE: '^(?=.{2,64}$)[A-Z][A-Z_]*[A-Z]$',
 	STRING_PATTERN_NAME: '^(?=.{2,64}$)[A-Z][A-Z\\d_]*[A-Z\\d]$',

--- a/test-helpers/test-fixtures.js
+++ b/test-helpers/test-fixtures.js
@@ -1,4 +1,4 @@
-const { DateTime } = require('neo4j-driver/lib/temporal-types.js');
+const { DateTime } = require('neo4j-driver/lib/temporal-types');
 
 const { driver } = require('./db-connection');
 


### PR DESCRIPTION
## Why?

Addressing this issue: https://github.com/Financial-Times/treecreeper/issues/362

## What?

Changes the regex matcher for systemCodes from `^[a-z][\\-a-z]+[a-z]$` to `^[a-z][a-z0-9-]+[a-z0-9]$`
