### PR TITLE
Implement option to make writes more efficient

### DIFF
--- a/packages/tc-api-rest-handlers/README.md
+++ b/packages/tc-api-rest-handlers/README.md
@@ -95,6 +95,7 @@ The `metadata` object is typically constructed from information sent to the appl
 |                    |                   | `replace`          | Existing relationships will be replaced by those specified in the body                                                                                                  |
 | richRelationship   | get               | `true`             | If the body has any relationships, it provides more information about the relationships than just their `code`                                                          |
 | force              | delete            | `true`             | Allows records to be deleted even if attached to other records                                                                                                          |
+| efficientWrite     | patch             | `true`             | Increases the efficiency of writes to large records but will only respond with a subgraph for the record.                                                               |
 
 ##### Field locking
 

--- a/packages/tc-api-rest-handlers/__tests__/patch-efficient.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-efficient.spec.js
@@ -1,0 +1,83 @@
+const { setupMocks } = require('../../../test-helpers');
+const { spyDbQuery } = require('../../../test-helpers/db-spies');
+
+const { patchHandler } = require('../patch');
+
+const patch = patchHandler();
+
+describe('rest PATCH efficient', () => {
+	const namespace = 'api-rest-handlers-patch-efficient';
+	const mainCode = `${namespace}-main`;
+	const leafCode = `${namespace}-leaf`;
+
+	const { createNode } = setupMocks(namespace);
+	it('only queries database for affected created relationships', async () => {
+		await createNode('RelationshipTestsOne', {
+			code: mainCode,
+		});
+		const dbQuerySpy = spyDbQuery();
+		const { status } = await patch({
+			type: 'RelationshipTestsOne',
+			code: mainCode,
+			body: { simpleRelationship: leafCode },
+			query: {
+				efficientWrite: true,
+				upsert: true,
+				relationshipAction: 'merge',
+			},
+		});
+		expect(status).toBe(200);
+		dbQuerySpy.mock.calls.forEach(([query]) => {
+			expect(query).toContain(
+				'OPTIONAL MATCH (node)-[relationship:MANY_TO_ONE]-(related)',
+			);
+		});
+	});
+
+	it('works with multiple created relationships', async () => {
+		await createNode('RelationshipTestsOne', {
+			code: mainCode,
+		});
+		const dbQuerySpy = spyDbQuery();
+		const { status } = await patch({
+			type: 'RelationshipTestsOne',
+			code: mainCode,
+			body: { simpleRelationship: leafCode, richRelationship: leafCode },
+			query: {
+				efficientWrite: true,
+				upsert: true,
+				relationshipAction: 'merge',
+			},
+		});
+		expect(status).toBe(200);
+		dbQuerySpy.mock.calls.forEach(([query]) => {
+			expect(query).toContain(
+				'OPTIONAL MATCH (node)-[relationship:MANY_TO_ONE|RICH_MANY_TO_ONE]-(related)',
+			);
+		});
+	});
+
+	it('only queries database for affected deleted relationships', async () => {
+		await createNode('RelationshipTestsOne', {
+			code: mainCode,
+		});
+		const dbQuerySpy = spyDbQuery();
+		const { status } = await patch({
+			type: 'RelationshipTestsOne',
+			code: mainCode,
+			body: { '!simpleRelationship': leafCode },
+			query: {
+				efficientWrite: true,
+				upsert: true,
+				relationshipAction: 'merge',
+			},
+		});
+		expect(status).toBe(200);
+		dbQuerySpy.mock.calls.forEach(([query]) => {
+			expect(query).toContain(
+				'OPTIONAL MATCH (node)-[relationship:MANY_TO_ONE]-(related)',
+			);
+		});
+	});
+
+});

--- a/packages/tc-api-rest-handlers/__tests__/patch-efficient.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-efficient.spec.js
@@ -80,4 +80,24 @@ describe('rest PATCH efficient', () => {
 		});
 	});
 
+	it("doesn't error when no relationships", async () => {
+		await createNode('PropertiesTest', {
+			code: mainCode,
+		});
+		const dbQuerySpy = spyDbQuery();
+		const { status } = await patch({
+			type: 'PropertiesTest',
+			code: mainCode,
+			body: { firstStringProperty: 'blah' },
+			query: {
+				efficientWrite: true,
+			},
+		});
+		expect(status).toBe(200);
+		dbQuerySpy.mock.calls.forEach(([query]) => {
+			expect(query).toContain(
+				'OPTIONAL MATCH (node)-[relationship]-(related)',
+			);
+		});
+	});
 });

--- a/packages/tc-api-rest-handlers/__tests__/patch-properties.spec.js
+++ b/packages/tc-api-rest-handlers/__tests__/patch-properties.spec.js
@@ -1,4 +1,4 @@
-const neo4jTemporalTypes = require('neo4j-driver/lib/temporal-types');
+const { types: neo4jTemporalTypes } = require('neo4j-driver');
 const { setupMocks, neo4jTest } = require('../../../test-helpers');
 const { dbUnavailable } = require('../../../test-helpers/error-stubs');
 const { spyDbQuery } = require('../../../test-helpers/db-spies');

--- a/packages/tc-api-rest-handlers/get.js
+++ b/packages/tc-api-rest-handlers/get.js
@@ -11,7 +11,7 @@ const getHandler =
 		const richRelationshipsFlag = query && query.richRelationships;
 
 		const [neo4jResult, docstoreResult] = await Promise.all([
-			getNeo4jRecord(type, code, richRelationshipsFlag),
+			getNeo4jRecord(type, code, { richRelationshipsFlag }),
 			documentStore ? documentStore.get(type, code) : { body: {} },
 		]);
 

--- a/packages/tc-api-rest-handlers/lib/diff-properties.js
+++ b/packages/tc-api-rest-handlers/lib/diff-properties.js
@@ -1,4 +1,4 @@
-const neo4jTemporalTypes = require('neo4j-driver/lib/temporal-types');
+const { types: neo4jTemporalTypes } = require('neo4j-driver');
 const { getType } = require('@financial-times/tc-schema-sdk');
 
 const isNullValue = val => val === null || val === '';

--- a/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-query-builder.js
@@ -52,7 +52,7 @@ const getBaseQuery = (type, method, willUpdateMeta) => {
 	}
 };
 
-const queryBuilder = (method, input, body = {}) => {
+const queryBuilder = (method, input, body = {}, relationshipTypes) => {
 	const { type, code, metadata = {}, query = {} } = input;
 	const { relationshipAction, lockFields, unlockFields, upsert } = query;
 	const { clientId } = metadata;
@@ -205,7 +205,7 @@ const queryBuilder = (method, input, body = {}) => {
 			context.willCreateRelationships ||
 			context.willDeleteRelationships;
 		queryParts.unshift(getBaseQuery(type, method, willUpdateMeta));
-		queryParts.push(getNeo4jRecordCypherQuery());
+		queryParts.push(getNeo4jRecordCypherQuery({ relationshipTypes }));
 		const neo4jQuery = queryParts.join('\n');
 		const neo4jResult = await executeQuery(neo4jQuery, parameters);
 

--- a/packages/tc-api-rest-handlers/lib/neo4j-type-conversion.js
+++ b/packages/tc-api-rest-handlers/lib/neo4j-type-conversion.js
@@ -2,8 +2,8 @@ const {
 	isDateTime,
 	isDate,
 	isTime,
-} = require('neo4j-driver/lib/temporal-types');
-const neo4jTemporalTypes = require('neo4j-driver/lib/temporal-types');
+	types: neo4jTemporalTypes,
+} = require('neo4j-driver');
 const { getType } = require('@financial-times/tc-schema-sdk');
 
 const entriesToObject = (map, [key, val]) => Object.assign(map, { [key]: val });

--- a/packages/tc-api-rest-handlers/lib/read-helpers.js
+++ b/packages/tc-api-rest-handlers/lib/read-helpers.js
@@ -4,16 +4,26 @@ const { executeQuery } = require('./neo4j-model');
 const getNeo4jRecordCypherQuery = ({
 	nodeName = 'node',
 	includeWithStatement = true,
-} = {}) => stripIndents`
+	relationshipTypes,
+} = {}) => {
+	return stripIndents`
 	${includeWithStatement ? `WITH DISTINCT ${nodeName}` : ''}
-	OPTIONAL MATCH (${nodeName})-[relationship]-(related)
+	OPTIONAL MATCH (${nodeName})-[relationship${
+		relationshipTypes ? `:${relationshipTypes.join('|')}` : ''
+	}]-(related)
 	RETURN ${nodeName}, relationship, labels(related) AS relatedLabels, related.code AS relatedCode, related._createdByRequest
 	ORDER BY related.code`;
+};
 
-const getNeo4jRecord = (type, code, richRelationshipsFlag) => {
+const getNeo4jRecord = (
+	type,
+	code,
+	richRelationshipsFlag,
+	relationshipTypes,
+) => {
 	return executeQuery(
 		`MATCH (node:${type} {code: $code})
-			${getNeo4jRecordCypherQuery()}`,
+			${getNeo4jRecordCypherQuery({ relationshipTypes })}`,
 		{ code },
 		richRelationshipsFlag,
 	);

--- a/packages/tc-api-rest-handlers/lib/read-helpers.js
+++ b/packages/tc-api-rest-handlers/lib/read-helpers.js
@@ -18,8 +18,7 @@ const getNeo4jRecordCypherQuery = ({
 const getNeo4jRecord = (
 	type,
 	code,
-	richRelationshipsFlag,
-	relationshipTypes,
+	{ richRelationshipsFlag, relationshipTypes } = {},
 ) => {
 	return executeQuery(
 		`MATCH (node:${type} {code: $code})

--- a/packages/tc-api-rest-handlers/lib/relationships/input.js
+++ b/packages/tc-api-rest-handlers/lib/relationships/input.js
@@ -226,11 +226,23 @@ const normaliseRelationshipProps = (type, body = {}) => {
 	});
 };
 
+const getUnderlyingRelationshipNames = (type, body = {}) => {
+	const isRelationship = identifyRelationships(type);
+	const relationships = Object.keys(body)
+		.filter(propName => isRelationship(unNegatePropertyName(propName)))
+		.map(name => name.replace(/^!/, ''));
+	const { properties } = getType(type);
+	return [
+		...new Set(relationships.map(name => properties[name].relationship)),
+	];
+};
+
 module.exports = {
 	getAllRelationships,
 	getWriteRelationships,
 	getChangedRelationships,
 	getRemovedRelationships,
+	getUnderlyingRelationshipNames,
 	containsRelationshipData,
 	normaliseRelationshipProps,
 	identifyRelationships,

--- a/packages/tc-api-rest-handlers/patch.js
+++ b/packages/tc-api-rest-handlers/patch.js
@@ -41,9 +41,12 @@ const patchHandler = ({ documentStore } = {}) => {
 				originalBody,
 			);
 		}
+		const relationshipTypes = efficientWrite
+			? underlyingRelationshipNames
+			: undefined;
 
 		const preflightRequest = await getNeo4jRecord(type, code, {
-			relationshipTypes: efficientWrite && underlyingRelationshipNames,
+			relationshipTypes,
 		});
 		if (!preflightRequest.hasRecords()) {
 			return Object.assign(await post(input), { status: 201 });
@@ -72,7 +75,7 @@ const patchHandler = ({ documentStore } = {}) => {
 				'MERGE',
 				input,
 				body,
-				efficientWrite && underlyingRelationshipNames,
+				relationshipTypes,
 			)
 				.constructProperties(initialContent)
 				.mergeLockFields(initialContent)

--- a/packages/tc-api-rest-handlers/patch.js
+++ b/packages/tc-api-rest-handlers/patch.js
@@ -42,12 +42,9 @@ const patchHandler = ({ documentStore } = {}) => {
 			);
 		}
 
-		const preflightRequest = await getNeo4jRecord(
-			type,
-			code,
-			null,
-			efficientWrite && underlyingRelationshipNames,
-		);
+		const preflightRequest = await getNeo4jRecord(type, code, {
+			relationshipTypes: efficientWrite && underlyingRelationshipNames,
+		});
 		if (!preflightRequest.hasRecords()) {
 			return Object.assign(await post(input), { status: 201 });
 		}

--- a/test-helpers/test-fixtures.js
+++ b/test-helpers/test-fixtures.js
@@ -1,4 +1,6 @@
-const { DateTime } = require('neo4j-driver/lib/temporal-types');
+const {
+	types: { DateTime },
+} = require('neo4j-driver');
 
 const { driver } = require('./db-connection');
 


### PR DESCRIPTION
## Why?

Fixes this https://github.com/Financial-Times/biz-ops-api/issues/534

## What?

When fetching data from the database (both the preflight request for diffing and the final response to user) only retrieves relationships relevant to the current request