### PR TITLE
Disable the Code field during edit

### DIFF
--- a/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
+++ b/packages/tc-ui/src/pages/edit/__tests__/e2e-edit-record.cyp.js
@@ -39,22 +39,28 @@ describe('End-to-end - record creation', () => {
 		cy.get('#firstStringProperty').should('have.text', 'new string');
 	});
 
-	it('cannot edit code of record', () => {
+	it('the code field of the record should be disabled', () => {
 		createRecord('PropertiesTest');
 		cy.visit(`/PropertiesTest/${code}/edit`);
-
-		cy.get('input[name="code"]').type('-test');
-		save();
-		cy.url().should('contain', `/PropertiesTest/${code}/edit`);
-		cy.get('.o-message__content-main').should(
-			'contain',
-			`Oops. Could not update PropertiesTest record for ${code}.`,
-		);
-		cy.get('.o-message__content-additional').should(
-			'contain',
-			`Conflicting code property \`${code}-test\` in payload for PropertiesTest ${code}`,
-		);
+		cy.get('input[name="code"]').should('be.disabled');
 	});
+
+	// it('cannot edit code of record', () => {
+	// 	createRecord('PropertiesTest');
+	// 	cy.visit(`/PropertiesTest/${code}/edit`);
+	//
+	// 	cy.get('input[name="code"]').type('-test');
+	// 	save();
+	// 	cy.url().should('contain', `/PropertiesTest/${code}/edit`);
+	// 	cy.get('.o-message__content-main').should(
+	// 		'contain',
+	// 		`Oops. Could not update PropertiesTest record for ${code}.`,
+	// 	);
+	// 	cy.get('.o-message__content-additional').should(
+	// 		'contain',
+	// 		`Conflicting code property \`${code}-test\` in payload for PropertiesTest ${code}`,
+	// 	);
+	// });
 
 	it('preserves data after error', () => {
 		createRecord('PropertiesTest');

--- a/packages/tc-ui/src/pages/edit/template.jsx
+++ b/packages/tc-ui/src/pages/edit/template.jsx
@@ -4,7 +4,14 @@ const { FormError } = require('../../lib/components/messages');
 const { Concept, Fieldset } = require('../../lib/components/structure');
 const { SaveButton, CancelButton } = require('../../lib/components/buttons');
 
-const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
+const PropertyInputs = ({
+	fields,
+	data,
+	type,
+	assignComponent,
+	hasError,
+	isEdit,
+}) => {
 	const propertyDefinitionsArray = Object.entries(fields);
 
 	const fieldsToLock = data._lockedFields
@@ -30,6 +37,7 @@ const PropertyInputs = ({ fields, data, type, assignComponent, hasError }) => {
 				: data[propertyName];
 
 			const viewModel = {
+				isEdit,
 				hasError,
 				parentCode: data.code,
 				propertyName,
@@ -126,6 +134,7 @@ const EditForm = props => {
 								description={description}
 							>
 								<PropertyInputs
+									isEdit={isEdit}
 									hasError={!!error}
 									fields={properties}
 									data={data}

--- a/packages/tc-ui/src/primitives/text/server.jsx
+++ b/packages/tc-ui/src/primitives/text/server.jsx
@@ -9,6 +9,7 @@ const localOnChange = (event, onChange) => {
 };
 
 const EditText = ({
+	isEdit,
 	propertyName,
 	value,
 	required,
@@ -16,28 +17,46 @@ const EditText = ({
 	disabled,
 	isNested,
 	parentCode,
+	type,
 	onChange,
 }) => {
 	const name = !isNested
 		? `${propertyName}${lockedBy || disabled ? '-disabled' : ''}`
 		: '';
 
+	// Special case for locking codes during edit
+	let additionalDescriptiveText;
+	if (type === 'Code' && isEdit) {
+		disabled = 'disabled';
+		additionalDescriptiveText =
+			"Codes cannot be edited. To modify an existing record's code create a new record with the desired code, then use the absorb API endpoint to merge records.";
+	}
+
 	return (
-		<span className="o-forms-input o-forms-input--text">
-			<input
-				name={name}
-				id={`id-${propertyName}`}
-				className="o-forms__text"
-				type="text"
-				defaultValue={value}
-				required={required ? 'required' : null}
-				disabled={disabled}
-				data-parent-code={parentCode}
-				onChange={
-					!isNested ? null : event => localOnChange(event, onChange)
-				}
-			/>
-		</span>
+		<>
+			{additionalDescriptiveText ? (
+				<span className="o-forms-title__prompt description-text">
+					{additionalDescriptiveText}
+				</span>
+			) : null}
+			<span className="o-forms-input o-forms-input--text">
+				<input
+					name={name}
+					id={`id-${propertyName}`}
+					className="o-forms__text"
+					type="text"
+					defaultValue={value}
+					required={required ? 'required' : null}
+					disabled={disabled}
+					data-parent-code={parentCode}
+					onChange={
+						!isNested
+							? null
+							: event => localOnChange(event, onChange)
+					}
+				/>
+			</span>
+		</>
 	);
 };
 


### PR DESCRIPTION
## Why?

-   Users can edit the `Code` field but if they do they receive an unhelpful message.

## What?

-   Disable the `Code` field during edit
-  Display a helpful message about the use of `absorb` to achieve a code rename

### Anything in particular you'd like to highlight to reviewers?
No

![image](https://user-images.githubusercontent.com/11228420/123435159-2a4e9a00-d5c5-11eb-8d7d-0481c455bd93.png)
